### PR TITLE
Paginate by URL

### DIFF
--- a/scm/client.go
+++ b/scm/client.go
@@ -52,10 +52,11 @@ type (
 	// Page represents parsed link rel values for
 	// pagination.
 	Page struct {
-		Next  int
-		Last  int
-		First int
-		Prev  int
+		Next    int
+		NextURL string
+		Last    int
+		First   int
+		Prev    int
 	}
 
 	// Rate represents the rate limit for the current
@@ -69,6 +70,7 @@ type (
 	// ListOptions specifies optional pagination
 	// parameters.
 	ListOptions struct {
+		URL  string
 		Page int
 		Size int
 	}

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -86,6 +87,9 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 // List returns the user repository list.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("2.0/repositories?%s", encodeListRoleOptions(opts))
+	if opts.URL != "" {
+		path = strings.TrimPrefix(opts.URL, s.client.BaseURL.String())
+	}
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	copyPagination(out.pagination, res)

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -88,7 +87,7 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("2.0/repositories?%s", encodeListRoleOptions(opts))
 	if opts.URL != "" {
-		path = strings.TrimPrefix(opts.URL, s.client.BaseURL.String())
+		path = opts.URL
 	}
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/bitbucket/testdata/repos-2.json
+++ b/scm/driver/bitbucket/testdata/repos-2.json
@@ -105,6 +105,5 @@
       "is_private": true,
       "description": "Examples on how to decorate various pages around Stash."
     }
-  ],
-  "next": "https:\/\/api.bitbucket.org\/2.0\/repositories?pagelen=1&after=PLACEHOLDER&role=member"
+  ]
 }

--- a/scm/driver/bitbucket/testdata/repos.json.golden
+++ b/scm/driver/bitbucket/testdata/repos.json.golden
@@ -11,5 +11,18 @@
         "Link": "https://bitbucket.org/atlassian/stash-example-plugin",
         "Created": "2013-04-15T03:05:05.595458Z",
         "Updated": "2018-04-01T16:36:35.970175Z"
+    },
+    {
+        "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+        "Namespace": "atlassian",
+        "Name": "stash-example-plugin",
+        "Perm": null,
+        "Branch": "master",
+        "Private": true,
+        "Clone": "https://bitbucket.org/atlassian/stash-example-plugin.git",
+        "CloneSSH": "git@bitbucket.org:atlassian/stash-example-plugin.git",
+        "Link": "https://bitbucket.org/atlassian/stash-example-plugin",
+        "Created": "2013-04-15T03:05:05.595458Z",
+        "Updated": "2018-04-01T16:36:35.970175Z"
     }
 ]

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -94,6 +94,7 @@ func copyPagination(from pagination, to *scm.Response) error {
 	if to == nil {
 		return nil
 	}
+	to.Page.NextURL = from.Next
 	uri, err := url.Parse(from.Next)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/drone/drone/issues/2533. 

Allows for optionally paginating with a URL to next page instead of page numbers and modifies the Bitbucket driver repo list implementation to do this.