### PR TITLE
stash: replace login to slug for FindLogin

### DIFF
--- a/scm/driver/stash/user.go
+++ b/scm/driver/stash/user.go
@@ -28,6 +28,7 @@ func (s *userService) Find(ctx context.Context) (*scm.User, *scm.Response, error
 	}
 	login := out.String()
 	login = strings.TrimSpace(login)
+	login = strings.Replace(login, "@", "_", -1)
 	return s.FindLogin(ctx, login)
 }
 


### PR DESCRIPTION
I didn't found any official description of slash's slug func, so This is pretty hack'y, but it makes the scm driver with logins like `name.lastname@company.name` at least usable

workaround for #31 