### PR TITLE
bitbucket: added "Before" field with the last commit before the push …

### DIFF
--- a/scm/driver/bitbucket/testdata/webhooks/push.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push.json.golden
@@ -1,5 +1,6 @@
 {
     "Ref": "refs/heads/master",
+    "Before": "40e7580cf11311d84a6e5e97e2cbba6df1675750",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",

--- a/scm/driver/bitbucket/webhook.go
+++ b/scm/driver/bitbucket/webhook.go
@@ -494,6 +494,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 	namespace, name := scm.Split(src.Repository.FullName)
 	dst := &scm.PushHook{
 		Ref: scm.ExpandRef(change.New.Name, "refs/heads/"),
+		Before: change.Old.Target.Hash,
 		Commit: scm.Commit{
 			Sha:     change.New.Target.Hash,
 			Message: change.New.Target.Message,


### PR DESCRIPTION
As stated in https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html, _old.target_ has _The details of the most recent commit before the push_.

Related issue: https://github.com/drone/go-scm/issues/23
