### PR TITLE
scm/driver/github: allow SkipVerify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/google/go-cmp v0.2.0
 	github.com/h2non/gock v1.0.9
 )
+
+go 1.13

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -46,6 +46,7 @@ type hook struct {
 		URL         string `json:"url"`
 		Secret      string `json:"secret"`
 		ContentType string `json:"content_type"`
+		InsecureSSL string `json:"insecure_ssl"`
 	} `json:"config"`
 }
 
@@ -112,6 +113,10 @@ func (s *RepositoryService) CreateHook(ctx context.Context, repo string, input *
 	in.Config.Secret = input.Secret
 	in.Config.ContentType = "json"
 	in.Config.URL = input.Target
+	in.Config.InsecureSSL = "0"
+	if input.SkipVerify {
+		in.Config.InsecureSSL = "1"
+	}
 	in.Events = append(
 		input.NativeEvents,
 		convertHookEvents(input.Events)...,

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -46,7 +46,7 @@ type hook struct {
 		URL         string `json:"url"`
 		Secret      string `json:"secret"`
 		ContentType string `json:"content_type"`
-		InsecureSSL string `json:"insecure_ssl"`
+		InsecureSSL string `json:"insecure_ssl,omitempty"`
 	} `json:"config"`
 }
 

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -113,7 +113,6 @@ func (s *RepositoryService) CreateHook(ctx context.Context, repo string, input *
 	in.Config.Secret = input.Secret
 	in.Config.ContentType = "json"
 	in.Config.URL = input.Target
-	in.Config.InsecureSSL = "0"
 	if input.SkipVerify {
 		in.Config.InsecureSSL = "1"
 	}

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -203,10 +203,11 @@ func convertHookList(from []*hook) []*scm.Hook {
 
 func convertHook(from *hook) *scm.Hook {
 	return &scm.Hook{
-		ID:     strconv.Itoa(from.ID),
-		Active: from.Active,
-		Target: from.Config.URL,
-		Events: from.Events,
+		ID:         strconv.Itoa(from.ID),
+		Active:     from.Active,
+		Target:     from.Config.URL,
+		Events:     from.Events,
+		SkipVerify: from.Config.InsecureSSL == "1",
 	}
 }
 


### PR DESCRIPTION
This PR adds support for `(scm.Hook).SkipVerify` to the github driver.

The docs describe the `insecure_ssl` config field:
https://developer.github.com/v3/repos/hooks/#create-a-hook