### PR TITLE
Fix Bitbucket link handling for branches with slashes

### DIFF
--- a/scm/driver/bitbucket/linker.go
+++ b/scm/driver/bitbucket/linker.go
@@ -7,6 +7,7 @@ package bitbucket
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -33,7 +34,7 @@ func (l *linker) Resource(ctx context.Context, repo string, ref scm.Reference) (
 		// a slash so we do this for branches with slashes in its names.
 		// See https://jira.atlassian.com/browse/BCLOUD-14422 for more information
 		//
-		if scm.BranchContainsSlash(t) {
+		if strings.Contains(t, "/") {
 			return fmt.Sprintf("%s%s/branch/%s", l.base, repo, t), nil
 		}
 

--- a/scm/driver/bitbucket/linker.go
+++ b/scm/driver/bitbucket/linker.go
@@ -25,7 +25,7 @@ func (l *linker) Resource(ctx context.Context, repo string, ref scm.Reference) (
 	case scm.IsPullRequest(ref.Path):
 		d := scm.ExtractPullRequest(ref.Path)
 		return fmt.Sprintf("%s%s/pull-requests/%d", l.base, repo, d), nil
-	case scm.IsBranch(ref.Path) && ref.Sha == "":
+	case ref.Sha == "":
 		t := scm.TrimRef(ref.Path)
 
 		// Bitbucket has a bug where the "source view" link for
@@ -33,8 +33,7 @@ func (l *linker) Resource(ctx context.Context, repo string, ref scm.Reference) (
 		// The link to the "branch view" works with names containing
 		// a slash so we do this for branches with slashes in its names.
 		// See https://jira.atlassian.com/browse/BCLOUD-14422 for more information
-		//
-		if strings.Contains(t, "/") {
+		if scm.IsBranch(ref.Path) && strings.Contains(t, "/") {
 			return fmt.Sprintf("%s%s/branch/%s", l.base, repo, t), nil
 		}
 

--- a/scm/driver/bitbucket/linker_test.go
+++ b/scm/driver/bitbucket/linker_test.go
@@ -35,6 +35,15 @@ func TestLink(t *testing.T) {
 			path: "refs/heads/master",
 			want: "https://bitbucket.org/octocat/hello-world/src/master",
 		},
+		{
+			path: "refs/heads/release/production",
+			want: "https://bitbucket.org/octocat/hello-world/branch/release/production",
+		},
+		{
+			path: "refs/heads/release/production",
+			sha:  "a7389057b0eb027e73b32a81e3c5923a71d01dde",
+			want: "https://bitbucket.org/octocat/hello-world/commits/a7389057b0eb027e73b32a81e3c5923a71d01dde",
+		},
 	}
 
 	for _, test := range tests {

--- a/scm/util.go
+++ b/scm/util.go
@@ -77,9 +77,3 @@ func IsPullRequest(ref string) bool {
 		strings.HasPrefix(ref, "refs/pull-request/") ||
 		strings.HasPrefix(ref, "refs/merge-requests/")
 }
-
-// BranchContainsSlash returns true if the branch name
-// contains a slash.
-func BranchContainsSlash(branch string) bool {
-	return strings.Contains(branch, "/")
-}

--- a/scm/util.go
+++ b/scm/util.go
@@ -58,6 +58,12 @@ func ExtractPullRequest(ref string) int {
 	return d
 }
 
+// IsBranch returns true if the reference path points to
+// a branch.
+func IsBranch(ref string) bool {
+	return strings.HasPrefix(ref, "refs/heads/")
+}
+
 // IsTag returns true if the reference path points to
 // a tag object.
 func IsTag(ref string) bool {
@@ -70,4 +76,10 @@ func IsPullRequest(ref string) bool {
 	return strings.HasPrefix(ref, "refs/pull/") ||
 		strings.HasPrefix(ref, "refs/pull-request/") ||
 		strings.HasPrefix(ref, "refs/merge-requests/")
+}
+
+// BranchContainsSlash returns true if the branch name
+// contains a slash.
+func BranchContainsSlash(branch string) bool {
+	return strings.Contains(branch, "/")
 }


### PR DESCRIPTION
Bitbucket has a bug where the "source view" link for a branch
which contains a slash results in a 404.

The link to the "branch view" works with names containing
a slash so we do this for branches with slashes in its names.

See https://jira.atlassian.com/browse/BCLOUD-14422 for more information.