### PR TITLE
gitea: added "Before" field with the last commit before the push is made

### DIFF
--- a/scm/driver/gitea/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/push.json.golden
@@ -1,5 +1,6 @@
 {
   "Ref": "refs/heads/master",
+  "Before": "9836a96a253cce25d17988fcf41b8c4205cf779f",
   "Repo": {
     "ID": "61",
     "Namespace": "gogits",

--- a/scm/driver/gitea/webhook.go
+++ b/scm/driver/gitea/webhook.go
@@ -210,6 +210,7 @@ func convertPushHook(dst *pushHook) *scm.PushHook {
 	if len(dst.Commits) > 0 {
 		return &scm.PushHook{
 			Ref: dst.Ref,
+			Before: dst.Before,
 			Commit: scm.Commit{
 				Sha:     dst.After,
 				Message: dst.Commits[0].Message,


### PR DESCRIPTION
same as pull request #32 but for the Gitea driver, so that we have access to this information via the DRONE_COMMIT_BEFORE env variable
