### PR TITLE
Change gitlab force_remove_source_branch to bool

### DIFF
--- a/scm/driver/gitlab/testdata/webhooks/pull_request_close.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_close.json
@@ -37,7 +37,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "force_remove_source_branch": false
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_comment_create.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_comment_create.json
@@ -69,7 +69,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "force_remove_source_branch": false
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_create.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_create.json
@@ -37,7 +37,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "force_remove_source_branch": false
     },
     "merge_status": "unchecked",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_merge.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_merge.json
@@ -37,7 +37,7 @@
     "merge_commit_sha": "78a76ee6b4992a6baf64c59fc4c44c7323d60438",
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "force_remove_source_branch": false
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json
@@ -37,7 +37,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "force_remove_source_branch": false
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/review_comment_create.json
+++ b/scm/driver/gitlab/testdata/webhooks/review_comment_create.json
@@ -96,7 +96,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "force_remove_source_branch": false
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -432,7 +432,7 @@ type (
 			MergeCommitSha interface{} `json:"merge_commit_sha"`
 			MergeError     interface{} `json:"merge_error"`
 			MergeParams    struct {
-				ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
+				ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
 			} `json:"merge_params"`
 			MergeStatus               string      `json:"merge_status"`
 			MergeUserID               interface{} `json:"merge_user_id"`
@@ -689,7 +689,7 @@ type (
 			MergeCommitSha interface{} `json:"merge_commit_sha"`
 			MergeError     interface{} `json:"merge_error"`
 			MergeParams    struct {
-				ForceRemoveSourceBranch string `json:"force_remove_source_branch"`
+				ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
 			} `json:"merge_params"`
 			MergeStatus               string      `json:"merge_status"`
 			MergeUserID               interface{} `json:"merge_user_id"`

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -419,21 +419,19 @@ type (
 			Homepage    string `json:"homepage"`
 		} `json:"repository"`
 		MergeRequest struct {
-			AssigneeID     interface{} `json:"assignee_id"`
-			AuthorID       int         `json:"author_id"`
-			CreatedAt      string      `json:"created_at"`
-			DeletedAt      interface{} `json:"deleted_at"`
-			Description    string      `json:"description"`
-			HeadPipelineID interface{} `json:"head_pipeline_id"`
-			ID             int         `json:"id"`
-			Iid            int         `json:"iid"`
-			LastEditedAt   interface{} `json:"last_edited_at"`
-			LastEditedByID interface{} `json:"last_edited_by_id"`
-			MergeCommitSha interface{} `json:"merge_commit_sha"`
-			MergeError     interface{} `json:"merge_error"`
-			MergeParams    struct {
-				ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
-			} `json:"merge_params"`
+			AssigneeID                interface{} `json:"assignee_id"`
+			AuthorID                  int         `json:"author_id"`
+			CreatedAt                 string      `json:"created_at"`
+			DeletedAt                 interface{} `json:"deleted_at"`
+			Description               string      `json:"description"`
+			HeadPipelineID            interface{} `json:"head_pipeline_id"`
+			ID                        int         `json:"id"`
+			Iid                       int         `json:"iid"`
+			LastEditedAt              interface{} `json:"last_edited_at"`
+			LastEditedByID            interface{} `json:"last_edited_by_id"`
+			MergeCommitSha            interface{} `json:"merge_commit_sha"`
+			MergeError                interface{} `json:"merge_error"`
+			MergeParams               interface{} `json:"-"`
 			MergeStatus               string      `json:"merge_status"`
 			MergeUserID               interface{} `json:"merge_user_id"`
 			MergeWhenPipelineSucceeds bool        `json:"merge_when_pipeline_succeeds"`
@@ -676,21 +674,19 @@ type (
 			HTTPURL           string      `json:"http_url"`
 		} `json:"project"`
 		ObjectAttributes struct {
-			AssigneeID     interface{} `json:"assignee_id"`
-			AuthorID       int         `json:"author_id"`
-			CreatedAt      string      `json:"created_at"`
-			DeletedAt      interface{} `json:"deleted_at"`
-			Description    string      `json:"description"`
-			HeadPipelineID interface{} `json:"head_pipeline_id"`
-			ID             int         `json:"id"`
-			Iid            int         `json:"iid"`
-			LastEditedAt   interface{} `json:"last_edited_at"`
-			LastEditedByID interface{} `json:"last_edited_by_id"`
-			MergeCommitSha interface{} `json:"merge_commit_sha"`
-			MergeError     interface{} `json:"merge_error"`
-			MergeParams    struct {
-				ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
-			} `json:"merge_params"`
+			AssigneeID                interface{} `json:"assignee_id"`
+			AuthorID                  int         `json:"author_id"`
+			CreatedAt                 string      `json:"created_at"`
+			DeletedAt                 interface{} `json:"deleted_at"`
+			Description               string      `json:"description"`
+			HeadPipelineID            interface{} `json:"head_pipeline_id"`
+			ID                        int         `json:"id"`
+			Iid                       int         `json:"iid"`
+			LastEditedAt              interface{} `json:"last_edited_at"`
+			LastEditedByID            interface{} `json:"last_edited_by_id"`
+			MergeCommitSha            interface{} `json:"merge_commit_sha"`
+			MergeError                interface{} `json:"merge_error"`
+			MergeParams               interface{} `json:"-"`
 			MergeStatus               string      `json:"merge_status"`
 			MergeUserID               interface{} `json:"merge_user_id"`
 			MergeWhenPipelineSucceeds bool        `json:"merge_when_pipeline_succeeds"`


### PR DESCRIPTION
Gitlab merge requests currently give an error message:
`json: cannot unmarshal bool into Go struct field .object_attributes.merge_params.force_remove_source_branch of type string`

Gitlab appear to have changed `force_remove_source_branch` to a boolean in the API. This PR updates those structs.