### PR TITLE
Set `Repository.Link` in various SCM drivers.

### DIFF
--- a/scm/driver/bitbucket/bitbucket.go
+++ b/scm/driver/bitbucket/bitbucket.go
@@ -115,6 +115,11 @@ type pagination struct {
 	Next    string `json:"next"`
 }
 
+// link represents Bitbucket link properties embedded in responses.
+type link struct {
+	Href string `json:"href"`
+}
+
 // Error represents a Bitbucket error.
 type Error struct {
 	Type string `json:"type"`

--- a/scm/driver/bitbucket/user.go
+++ b/scm/driver/bitbucket/user.go
@@ -35,16 +35,10 @@ func (s *userService) FindEmail(ctx context.Context) (string, *scm.Response, err
 type user struct {
 	Login string `json:"username"`
 	Name  string `json:"display_name"`
-	Links links  `json:"links"`
-}
-
-type links struct {
-	HTML   link `json:"html"`
-	Avatar link `json:"avatar"`
-}
-
-type link struct {
-	Href string `json:"href"`
+	Links struct {
+		HTML   link `json:"html"`
+		Avatar link `json:"avatar"`
+	} `json:"links"`
 }
 
 func convertUser(from *user) *scm.User {

--- a/scm/driver/gitea/repo.go
+++ b/scm/driver/gitea/repo.go
@@ -189,6 +189,7 @@ func convertRepository(src *repository) *scm.Repository {
 		Private:   src.Private,
 		Clone:     src.CloneURL,
 		CloneSSH:  src.SSHURL,
+		Link:      src.HTMLURL,
 	}
 }
 

--- a/scm/driver/gitea/testdata/repo.json.golden
+++ b/scm/driver/gitea/testdata/repo.json.golden
@@ -11,7 +11,7 @@
     "Private": true,
     "Clone": "https://try.gitea.io/go-gitea/gitea.git",
     "CloneSSH": "git@try.gitea.io:go-gitea/gitea.git",
-    "Link": "",
+    "Link": "https://try.gitea.io/go-gitea/gitea",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
 }

--- a/scm/driver/gitea/testdata/repos.json.golden
+++ b/scm/driver/gitea/testdata/repos.json.golden
@@ -12,7 +12,7 @@
         "Private": true,
         "Clone": "https://try.gitea.io/go-gitea/gitea.git",
         "CloneSSH": "git@try.gitea.io:go-gitea/gitea.git",
-        "Link": "",
+        "Link": "https://try.gitea.io/go-gitea/gitea",
         "Created": "0001-01-01T00:00:00Z",
         "Updated": "0001-01-01T00:00:00Z"
     }

--- a/scm/driver/gitea/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/branch_create.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/branch_delete.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/branch_delete.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/issue_comment_created.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/issue_comment_created.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/issues_opened.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/issues_opened.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_closed.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_closed.json.golden
@@ -13,7 +13,7 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_comment_created.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_comment_created.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_edited.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_edited.json.golden
@@ -13,7 +13,7 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_merged.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_merged.json.golden
@@ -13,7 +13,7 @@
         "Private": false,
         "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
         "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-        "Link": "",
+        "Link": "https://try.gitea.io/jcitizen/my-repo",
         "Created": "0001-01-01T00:00:00Z",
         "Updated": "0001-01-01T00:00:00Z"
     },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_opened.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_opened.json.golden
@@ -13,7 +13,7 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_reopened.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_reopened.json.golden
@@ -13,7 +13,7 @@
         "Private": false,
         "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
         "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-        "Link": "",
+        "Link": "https://try.gitea.io/jcitizen/my-repo",
         "Created": "0001-01-01T00:00:00Z",
         "Updated": "0001-01-01T00:00:00Z"
     },

--- a/scm/driver/gitea/testdata/webhooks/pull_request_synchronized.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_synchronized.json.golden
@@ -13,7 +13,7 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/push.json.golden
@@ -10,7 +10,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/tag_create.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitea/testdata/webhooks/tag_delete.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/tag_delete.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gitea.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -179,6 +179,7 @@ func convertRepository(from *repository) *scm.Repository {
 		Private:   convertPrivate(from.Visibility),
 		Clone:     from.HTTPURL,
 		CloneSSH:  from.SSHURL,
+		Link:      from.WebURL,
 		Perm: &scm.Perm{
 			Pull:  true,
 			Push:  canPush(from),

--- a/scm/driver/gitlab/testdata/repo.json.golden
+++ b/scm/driver/gitlab/testdata/repo.json.golden
@@ -11,7 +11,7 @@
     "Private": false,
     "Clone": "https://gitlab.com/diaspora/diaspora.git",
     "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
-    "Link": "",
+    "Link": "https://gitlab.com/diaspora/diaspora",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
 }

--- a/scm/driver/gitlab/testdata/repos.json.golden
+++ b/scm/driver/gitlab/testdata/repos.json.golden
@@ -12,7 +12,7 @@
         "Private": false,
         "Clone": "https://gitlab.com/diaspora/diaspora.git",
         "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
-        "Link": "",
+        "Link": "https://gitlab.com/diaspora/diaspora",
         "Created": "0001-01-01T00:00:00Z",
         "Updated": "0001-01-01T00:00:00Z"
     }

--- a/scm/driver/gitlab/testdata/subgroup.json.golden
+++ b/scm/driver/gitlab/testdata/subgroup.json.golden
@@ -11,7 +11,7 @@
     "Private": false,
     "Clone": "https://gitlab.com/gitlab-org/gitter/gitter-demo-app.git",
     "CloneSSH": "git@gitlab.com:gitlab-org/gitter/gitter-demo-app.git",
-    "Link": "",
+    "Link": "https://gitlab.com/gitlab-org/gitter/gitter-demo-app",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
 }

--- a/scm/driver/gogs/repo.go
+++ b/scm/driver/gogs/repo.go
@@ -150,6 +150,7 @@ func convertRepository(src *repository) *scm.Repository {
 		Private:   src.Private,
 		Clone:     src.CloneURL,
 		CloneSSH:  src.SSHURL,
+		Link:      src.HTMLURL,
 	}
 }
 

--- a/scm/driver/gogs/testdata/repo.json.golden
+++ b/scm/driver/gogs/testdata/repo.json.golden
@@ -11,7 +11,7 @@
     "Private": true,
     "Clone": "http://gogs.io/drone/cover.git",
     "CloneSSH": "git@localhost:drone/cover.git",
-    "Link": "",
+    "Link": "http://gogs.io/drone/cover",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
 }

--- a/scm/driver/gogs/testdata/repos.json.golden
+++ b/scm/driver/gogs/testdata/repos.json.golden
@@ -12,7 +12,7 @@
         "Private": true,
         "Clone": "http://gogs.io/drone/cover.git",
         "CloneSSH": "git@localhost:drone/cover.git",
-        "Link": "",
+        "Link": "http://gogs.io/drone/cover",
         "Created": "0001-01-01T00:00:00Z",
         "Updated": "0001-01-01T00:00:00Z"
     }

--- a/scm/driver/gogs/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/branch_create.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/branch_delete.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/branch_delete.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/issue_comment_created.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/issue_comment_created.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/issues_opened.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/issues_opened.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/pull_request_closed.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/pull_request_closed.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/pull_request_comment_created.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/pull_request_comment_created.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/pull_request_edited.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/pull_request_edited.json.golden
@@ -9,7 +9,7 @@
       "Private": true,
       "Clone": "http://try.gogs.io/gogits/hello-world.git",
       "CloneSSH": "git@localhost:gogits/hello-world.git",
-      "Link": "",
+      "Link": "http://try.gogs.io/gogits/hello-world",
       "Created": "0001-01-01T00:00:00Z",
       "Updated": "0001-01-01T00:00:00Z"
     },

--- a/scm/driver/gogs/testdata/webhooks/pull_request_opened.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/pull_request_opened.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/pull_request_synchronized.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/pull_request_synchronized.json.golden
@@ -9,7 +9,7 @@
       "Private": true,
       "Clone": "http://try.gogs.io/gogits/hello-world.git",
       "CloneSSH": "git@localhost:gogits/hello-world.git",
-      "Link": "",
+      "Link": "http://try.gogs.io/gogits/hello-world",
       "Created": "0001-01-01T00:00:00Z",
       "Updated": "0001-01-01T00:00:00Z"
     },

--- a/scm/driver/gogs/testdata/webhooks/push.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/push.json.golden
@@ -9,7 +9,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/tag_create.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },

--- a/scm/driver/gogs/testdata/webhooks/tag_delete.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/tag_delete.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "http://try.gogs.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
+    "Link": "http://try.gogs.io/gogits/hello-world",
     "Created": "0001-01-01T00:00:00Z",
     "Updated": "0001-01-01T00:00:00Z"
   },


### PR DESCRIPTION
The `Repository.Link` field can be useful in a number of places. For example, it can be used to construct the URL to the SCM web viewer of a given content file, especially when some major SCM services doesn't provide that in content service responses.