### PR TITLE
fix FindCommit for branch name with slash for gitlab

### DIFF
--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -7,6 +7,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -24,7 +25,7 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 }
 
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/commits/%s", encode(repo), scm.TrimRef(ref))
+	path := fmt.Sprintf("api/v4/projects/%s/repository/commits/%s", encode(repo), url.PathEscape(scm.TrimRef(ref)))
 	out := new(commit)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	return convertCommit(out), res, err


### PR DESCRIPTION
fix FindCommit can not get commit for branch name with slash (like feature/new) from gitlab.
Reference: https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit