### PR TITLE
Supporetd `skip_cert_verification` for bitbucket webhook registration.

### DIFF
--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -51,7 +51,7 @@ type hooks struct {
 type hook struct {
 	Description          string   `json:"description"`
 	URL                  string   `json:"url"`
-	SkipCertVerification bool     `json:"skip_cert_verification"`
+	SkipCertVerification bool     `json:"skip_cert_verification,omitempty"`
 	Active               bool     `json:"active"`
 	Events               []string `json:"events"`
 	UUID                 string   `json:"uuid"`

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -58,10 +58,11 @@ type hook struct {
 }
 
 type hookInput struct {
-	Description string   `json:"description"`
-	URL         string   `json:"url"`
-	Active      bool     `json:"active"`
-	Events      []string `json:"events"`
+	Description          string   `json:"description"`
+	URL                  string   `json:"url"`
+	SkipCertVerification bool     `json:"skip_cert_verification"`
+	Active               bool     `json:"active"`
+	Events               []string `json:"events"`
 }
 
 type repositoryService struct {
@@ -135,6 +136,7 @@ func (s *repositoryService) CreateHook(ctx context.Context, repo string, input *
 	path := fmt.Sprintf("2.0/repositories/%s/hooks", repo)
 	in := new(hookInput)
 	in.URL = target.String()
+	in.SkipCertVerification = input.SkipVerify
 	in.Active = true
 	in.Description = input.Name
 	in.Events = append(

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -60,7 +60,7 @@ type hook struct {
 type hookInput struct {
 	Description          string   `json:"description"`
 	URL                  string   `json:"url"`
-	SkipCertVerification bool     `json:"skip_cert_verification"`
+	SkipCertVerification bool     `json:"skip_cert_verification,omitempty"`
 	Active               bool     `json:"active"`
 	Events               []string `json:"events"`
 }


### PR DESCRIPTION
This is undocumented in [Bitbucket REST API 2.0](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/hooks) but I tested it against `bitbucket.org` and it's a valid parameter. The UI also has a corresponding setting.