### PR TITLE
Fix pagination being ignored for Gitea

### DIFF
--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -36,8 +36,8 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/branches", repo)
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/branches?%s", repo, encodeListOptions(opts))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err

--- a/scm/driver/gitea/issue.go
+++ b/scm/driver/gitea/issue.go
@@ -27,15 +27,15 @@ func (s *issueService) FindComment(ctx context.Context, repo string, index, id i
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *issueService) List(ctx context.Context, repo string, _ scm.IssueListOptions) ([]*scm.Issue, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues", repo)
+func (s *issueService) List(ctx context.Context, repo string, opts scm.IssueListOptions) ([]*scm.Issue, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/issues?%s", repo, encodeIssueListOptions(opts))
 	out := []*issue{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertIssueList(out), res, err
 }
 
-func (s *issueService) ListComments(ctx context.Context, repo string, index int, _ scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues/%d/comments", repo, index)
+func (s *issueService) ListComments(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/issues/%d/comments?%s", repo, index, encodeListOptions(opts))
 	out := []*issueComment{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertIssueCommentList(out), res, err

--- a/scm/driver/gitea/org.go
+++ b/scm/driver/gitea/org.go
@@ -26,9 +26,10 @@ func (s *organizationService) FindMembership(ctx context.Context, name, username
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *organizationService) List(ctx context.Context, _ scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
-	var out []*org
-	res, err := s.client.do(ctx, "GET", "api/v1/user/orgs", nil, &out)
+func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/user/orgs?%s", encodeListOptions(opts))
+	out := []*org{}
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertOrgList(out), res, err
 }
 

--- a/scm/driver/gitea/pr.go
+++ b/scm/driver/gitea/pr.go
@@ -28,7 +28,7 @@ func (s *pullService) FindComment(context.Context, string, int, int) (*scm.Comme
 }
 
 func (s *pullService) List(ctx context.Context, repo string, opts scm.PullRequestListOptions) ([]*scm.PullRequest, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/pulls", repo)
+	path := fmt.Sprintf("api/v1/repos/%s/pulls?%s", repo, encodePullRequestListOptions(opts))
 	out := []*pr{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertPullRequests(out), res, err

--- a/scm/driver/gitea/repo.go
+++ b/scm/driver/gitea/repo.go
@@ -39,22 +39,22 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	return convertRepository(out).Perm, res, err
 }
 
-func (s *repositoryService) List(ctx context.Context, _ scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/user/repos")
+func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/user/repos?%s", encodeListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertRepositoryList(out), res, err
 }
 
-func (s *repositoryService) ListHooks(ctx context.Context, repo string, _ scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/hooks", repo)
+func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/hooks?%s", repo, encodeListOptions(opts))
 	out := []*hook{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertHookList(out), res, err
 }
 
-func (s *repositoryService) ListStatus(ctx context.Context, repo string, ref string, _ scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/statuses/%s", repo, ref)
+func (s *repositoryService) ListStatus(ctx context.Context, repo string, ref string, opts scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/statuses/%s?%s", repo, ref, encodeListOptions(opts))
 	out := []*status{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertStatusList(out), res, err

--- a/scm/driver/gitea/util.go
+++ b/scm/driver/gitea/util.go
@@ -17,7 +17,7 @@ func encodeListOptions(opts scm.ListOptions) string {
 		params.Set("page", strconv.Itoa(opts.Page))
 	}
 	if opts.Size != 0 {
-		params.Set("per_page", strconv.Itoa(opts.Size))
+		params.Set("limit", strconv.Itoa(opts.Size))
 	}
 	return params.Encode()
 }
@@ -28,7 +28,7 @@ func encodeIssueListOptions(opts scm.IssueListOptions) string {
 		params.Set("page", strconv.Itoa(opts.Page))
 	}
 	if opts.Size != 0 {
-		params.Set("per_page", strconv.Itoa(opts.Size))
+		params.Set("limit", strconv.Itoa(opts.Size))
 	}
 	if opts.Open && opts.Closed {
 		params.Set("state", "all")
@@ -44,7 +44,7 @@ func encodePullRequestListOptions(opts scm.PullRequestListOptions) string {
 		params.Set("page", strconv.Itoa(opts.Page))
 	}
 	if opts.Size != 0 {
-		params.Set("per_page", strconv.Itoa(opts.Size))
+		params.Set("limit", strconv.Itoa(opts.Size))
 	}
 	if opts.Open && opts.Closed {
 		params.Set("state", "all")

--- a/scm/driver/gitea/util.go
+++ b/scm/driver/gitea/util.go
@@ -1,0 +1,55 @@
+// Copyright 2017 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/drone/go-scm/scm"
+)
+
+func encodeListOptions(opts scm.ListOptions) string {
+	params := url.Values{}
+	if opts.Page != 0 {
+		params.Set("page", strconv.Itoa(opts.Page))
+	}
+	if opts.Size != 0 {
+		params.Set("per_page", strconv.Itoa(opts.Size))
+	}
+	return params.Encode()
+}
+
+func encodeIssueListOptions(opts scm.IssueListOptions) string {
+	params := url.Values{}
+	if opts.Page != 0 {
+		params.Set("page", strconv.Itoa(opts.Page))
+	}
+	if opts.Size != 0 {
+		params.Set("per_page", strconv.Itoa(opts.Size))
+	}
+	if opts.Open && opts.Closed {
+		params.Set("state", "all")
+	} else if opts.Closed {
+		params.Set("state", "closed")
+	}
+	return params.Encode()
+}
+
+func encodePullRequestListOptions(opts scm.PullRequestListOptions) string {
+	params := url.Values{}
+	if opts.Page != 0 {
+		params.Set("page", strconv.Itoa(opts.Page))
+	}
+	if opts.Size != 0 {
+		params.Set("per_page", strconv.Itoa(opts.Size))
+	}
+	if opts.Open && opts.Closed {
+		params.Set("state", "all")
+	} else if opts.Closed {
+		params.Set("state", "closed")
+	}
+	return params.Encode()
+}

--- a/scm/driver/gitea/util_test.go
+++ b/scm/driver/gitea/util_test.go
@@ -15,7 +15,7 @@ func Test_encodeListOptions(t *testing.T) {
 		Page: 10,
 		Size: 30,
 	}
-	want := "page=10&per_page=30"
+	want := "page=10&limit=30"
 	got := encodeListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded list options %q, got %q", want, got)
@@ -29,7 +29,7 @@ func Test_encodeIssueListOptions(t *testing.T) {
 		Open:   true,
 		Closed: true,
 	}
-	want := "page=10&per_page=30&state=all"
+	want := "page=10&limit=30&state=all"
 	got := encodeIssueListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded issue list options %q, got %q", want, got)
@@ -43,7 +43,7 @@ func Test_encodeIssueListOptions_Closed(t *testing.T) {
 		Open:   false,
 		Closed: true,
 	}
-	want := "page=10&per_page=30&state=closed"
+	want := "page=10&limit=30&state=closed"
 	got := encodeIssueListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded issue list options %q, got %q", want, got)
@@ -58,7 +58,7 @@ func Test_encodePullRequestListOptions(t *testing.T) {
 		Open:   true,
 		Closed: true,
 	}
-	want := "page=10&per_page=30&state=all"
+	want := "page=10&limit=30&state=all"
 	got := encodePullRequestListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded pr list options %q, got %q", want, got)
@@ -73,7 +73,7 @@ func Test_encodePullRequestListOptions_Closed(t *testing.T) {
 		Open:   false,
 		Closed: true,
 	}
-	want := "page=10&per_page=30&state=closed"
+	want := "page=10&limit=30&state=closed"
 	got := encodePullRequestListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded pr list options %q, got %q", want, got)

--- a/scm/driver/gitea/util_test.go
+++ b/scm/driver/gitea/util_test.go
@@ -15,7 +15,7 @@ func Test_encodeListOptions(t *testing.T) {
 		Page: 10,
 		Size: 30,
 	}
-	want := "page=10&limit=30"
+	want := "limit=30&page=10"
 	got := encodeListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded list options %q, got %q", want, got)
@@ -29,7 +29,7 @@ func Test_encodeIssueListOptions(t *testing.T) {
 		Open:   true,
 		Closed: true,
 	}
-	want := "page=10&limit=30&state=all"
+	want := "limit=30&page=10&state=all"
 	got := encodeIssueListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded issue list options %q, got %q", want, got)
@@ -43,7 +43,7 @@ func Test_encodeIssueListOptions_Closed(t *testing.T) {
 		Open:   false,
 		Closed: true,
 	}
-	want := "page=10&limit=30&state=closed"
+	want := "limit=30&page=10&state=closed"
 	got := encodeIssueListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded issue list options %q, got %q", want, got)
@@ -58,7 +58,7 @@ func Test_encodePullRequestListOptions(t *testing.T) {
 		Open:   true,
 		Closed: true,
 	}
-	want := "page=10&limit=30&state=all"
+	want := "limit=30&page=10&state=all"
 	got := encodePullRequestListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded pr list options %q, got %q", want, got)
@@ -73,7 +73,7 @@ func Test_encodePullRequestListOptions_Closed(t *testing.T) {
 		Open:   false,
 		Closed: true,
 	}
-	want := "page=10&limit=30&state=closed"
+	want := "limit=30&page=10&state=closed"
 	got := encodePullRequestListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded pr list options %q, got %q", want, got)

--- a/scm/driver/gitea/util_test.go
+++ b/scm/driver/gitea/util_test.go
@@ -1,0 +1,81 @@
+// Copyright 2017 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"testing"
+
+	"github.com/drone/go-scm/scm"
+)
+
+func Test_encodeListOptions(t *testing.T) {
+	opts := scm.ListOptions{
+		Page: 10,
+		Size: 30,
+	}
+	want := "page=10&per_page=30"
+	got := encodeListOptions(opts)
+	if got != want {
+		t.Errorf("Want encoded list options %q, got %q", want, got)
+	}
+}
+
+func Test_encodeIssueListOptions(t *testing.T) {
+	opts := scm.IssueListOptions{
+		Page:   10,
+		Size:   30,
+		Open:   true,
+		Closed: true,
+	}
+	want := "page=10&per_page=30&state=all"
+	got := encodeIssueListOptions(opts)
+	if got != want {
+		t.Errorf("Want encoded issue list options %q, got %q", want, got)
+	}
+}
+
+func Test_encodeIssueListOptions_Closed(t *testing.T) {
+	opts := scm.IssueListOptions{
+		Page:   10,
+		Size:   30,
+		Open:   false,
+		Closed: true,
+	}
+	want := "page=10&per_page=30&state=closed"
+	got := encodeIssueListOptions(opts)
+	if got != want {
+		t.Errorf("Want encoded issue list options %q, got %q", want, got)
+	}
+}
+
+func Test_encodePullRequestListOptions(t *testing.T) {
+	t.Parallel()
+	opts := scm.PullRequestListOptions{
+		Page:   10,
+		Size:   30,
+		Open:   true,
+		Closed: true,
+	}
+	want := "page=10&per_page=30&state=all"
+	got := encodePullRequestListOptions(opts)
+	if got != want {
+		t.Errorf("Want encoded pr list options %q, got %q", want, got)
+	}
+}
+
+func Test_encodePullRequestListOptions_Closed(t *testing.T) {
+	t.Parallel()
+	opts := scm.PullRequestListOptions{
+		Page:   10,
+		Size:   30,
+		Open:   false,
+		Closed: true,
+	}
+	want := "page=10&per_page=30&state=closed"
+	got := encodePullRequestListOptions(opts)
+	if got != want {
+		t.Errorf("Want encoded pr list options %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Fixes #64

Gitea implementation was completely ignoring opts from Drone, so after we introduced proper pagination headers in v1.12, Drone would ask go-scm for page 2, and go-scm would request page 1 and return it, causing infinite loop of requests.