### PR TITLE
Added UpdateHook method to RepositoryService.

### DIFF
--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -254,20 +254,6 @@ func TestRepositoryHookList(t *testing.T) {
 	}
 }
 
-func TestRepositoryHookDelete(t *testing.T) {
-	defer gock.Off()
-
-	gock.New("https://api.bitbucket.org").
-		Delete("/2.0/repositories/atlassian/stash-example-plugin/hooks/{d53603cc-3f67-45ea-b310-aaa5ef6ec061}").
-		Reply(204).Done()
-
-	client, _ := New("https://api.bitbucket.org")
-	_, err := client.Repositories.DeleteHook(context.Background(), "atlassian/stash-example-plugin", "{d53603cc-3f67-45ea-b310-aaa5ef6ec061}")
-	if err != nil {
-		t.Error(err)
-	}
-}
-
 func TestRepositoryHookCreate(t *testing.T) {
 	defer gock.Off()
 
@@ -291,6 +277,46 @@ func TestRepositoryHookCreate(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
+	}
+}
+
+func TestRepositoryHookUpdate(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Put("/2.0/repositories/atlassian/stash-example-plugin/hooks/{d53603cc-3f67-45ea-b310-aaa5ef6ec061}").
+		Reply(200).
+		Type("application/json").
+		File("testdata/hook.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	got, _, err := client.Repositories.UpdateHook(context.Background(), "atlassian/stash-example-plugin", "{d53603cc-3f67-45ea-b310-aaa5ef6ec061}", &scm.HookInput{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := new(scm.Hook)
+	raw, _ := ioutil.ReadFile("testdata/hook.json.golden")
+	json.Unmarshal(raw, want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestRepositoryHookDelete(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Delete("/2.0/repositories/atlassian/stash-example-plugin/hooks/{d53603cc-3f67-45ea-b310-aaa5ef6ec061}").
+		Reply(204).Done()
+
+	client, _ := New("https://api.bitbucket.org")
+	_, err := client.Repositories.DeleteHook(context.Background(), "atlassian/stash-example-plugin", "{d53603cc-3f67-45ea-b310-aaa5ef6ec061}")
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/scm/driver/gitea/repo_test.go
+++ b/scm/driver/gitea/repo_test.go
@@ -190,6 +190,31 @@ func TestHookCreate(t *testing.T) {
 	}
 }
 
+func TestHookUpdate(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://try.gitea.io").
+		Patch("/api/v1/repos/go-gitea/gitea/hooks/20").
+		Reply(200).
+		Type("application/json").
+		File("testdata/hook.json")
+
+	client, _ := New("https://try.gitea.io")
+	got, _, err := client.Repositories.UpdateHook(context.Background(), "go-gitea/gitea", "20", &scm.HookInput{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := new(scm.Hook)
+	raw, _ := ioutil.ReadFile("testdata/hook.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
 func TestHookDelete(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -153,6 +153,10 @@ func (s *repositoryService) CreateStatus(ctx context.Context, repo, ref string, 
 	return convertStatus(out), res, err
 }
 
+func (s *repositoryService) UpdateHook(ctx context.Context, repo string, id string, input *scm.HookInput) (*scm.Hook, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *repositoryService) DeleteHook(ctx context.Context, repo string, id string) (*scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/hooks/%s", encode(repo), id)
 	return s.client.do(ctx, "DELETE", path, nil, nil)

--- a/scm/driver/gogs/repo.go
+++ b/scm/driver/gogs/repo.go
@@ -77,6 +77,23 @@ func (s *repositoryService) CreateStatus(context.Context, string, string, *scm.S
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *repositoryService) UpdateHook(ctx context.Context, repo, id string, input *scm.HookInput) (*scm.Hook, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/hooks/%s", repo, id)
+	in := new(hook)
+	in.Type = "gogs"
+	in.Active = true
+	in.Config.Secret = input.Secret
+	in.Config.ContentType = "json"
+	in.Config.URL = input.Target
+	in.Events = append(
+		input.NativeEvents,
+		convertHookEvent(input.Events)...,
+	)
+	out := new(hook)
+	res, err := s.client.do(ctx, "PATCH", path, in, out)
+	return convertHook(out), res, err
+}
+
 func (s *repositoryService) DeleteHook(ctx context.Context, repo string, id string) (*scm.Response, error) {
 	path := fmt.Sprintf("api/v1/repos/%s/hooks/%s", repo, id)
 	return s.client.do(ctx, "DELETE", path, nil, nil)

--- a/scm/driver/gogs/repo_test.go
+++ b/scm/driver/gogs/repo_test.go
@@ -19,7 +19,7 @@ import (
 // repository sub-tests
 //
 
-func TestRepoFind(t *testing.T) {
+func TestRepositoryFind(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -44,7 +44,7 @@ func TestRepoFind(t *testing.T) {
 	}
 }
 
-func TestRepoFindPerm(t *testing.T) {
+func TestRepositoryPerms(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -69,7 +69,7 @@ func TestRepoFindPerm(t *testing.T) {
 	}
 }
 
-func TestRepoList(t *testing.T) {
+func TestRepositoryList(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -94,7 +94,7 @@ func TestRepoList(t *testing.T) {
 	}
 }
 
-func TestRepoNotFound(t *testing.T) {
+func TestRepositoryNotFound(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -115,7 +115,7 @@ func TestRepoNotFound(t *testing.T) {
 // hook sub-tests
 //
 
-func TestHookFind(t *testing.T) {
+func TestRepositoryHookFind(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -140,7 +140,7 @@ func TestHookFind(t *testing.T) {
 	}
 }
 
-func TestHookList(t *testing.T) {
+func TestRepositoryHookList(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -165,7 +165,7 @@ func TestHookList(t *testing.T) {
 	}
 }
 
-func TestHookCreate(t *testing.T) {
+func TestRepositoryHookCreate(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").
@@ -190,7 +190,32 @@ func TestHookCreate(t *testing.T) {
 	}
 }
 
-func TestHookDelete(t *testing.T) {
+func TestRepositoryHookUpdate(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://try.gogs.io").
+		Patch("/api/v1/repos/gogits/gogs/hooks").
+		Reply(200).
+		Type("application/json").
+		File("testdata/hook.json")
+
+	client, _ := New("https://try.gogs.io")
+	got, _, err := client.Repositories.UpdateHook(context.Background(), "gogits/gogs", "20", &scm.HookInput{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := new(scm.Hook)
+	raw, _ := ioutil.ReadFile("testdata/hook.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestRepositoryHookDelete(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://try.gogs.io").

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -124,13 +124,16 @@ type (
 		// ListStatus returns a list of commit statuses.
 		ListStatus(context.Context, string, string, ListOptions) ([]*Status, *Response, error)
 
-		// CreateHook creates a new repository webhook.
+		// CreateHook creates a new repository hook.
 		CreateHook(context.Context, string, *HookInput) (*Hook, *Response, error)
 
 		// CreateStatus creates a new commit status.
 		CreateStatus(context.Context, string, string, *StatusInput) (*Status, *Response, error)
 
-		// DeleteHook deletes a repository webhook.
+		// UpdateHook updates an existing repository hook.
+		UpdateHook(context.Context, string, string, *HookInput) (*Hook, *Response, error)
+
+		// DeleteHook deletes a repository hook.
 		DeleteHook(context.Context, string, string) (*Response, error)
 	}
 )


### PR DESCRIPTION
The new `UpdateHook` method in `RepositoryService` would update an existing
SCM webhook and overwrite the list of events to watch.

In this patch, `UpdateHook` is not supported in the GitLab driver. It is
implemented separately in a followup patch.