### PR TITLE
Fixed github integration tests.

### DIFF
--- a/scm/driver/github/integration/github_test.go
+++ b/scm/driver/github/integration/github_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/drone/go-scm/scm/transport"
 )
 
-func TestGitLab(t *testing.T) {
+func TestGitHub(t *testing.T) {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		t.Skipf("missing GITHUB_TOKEN environment variable")
 		return

--- a/scm/driver/github/integration/issue_test.go
+++ b/scm/driver/github/integration/issue_test.go
@@ -113,7 +113,7 @@ func testIssue(issue *scm.Issue) func(t *testing.T) {
 			t.Errorf("Want issue Author Login %q, got %q", want, got)
 		}
 		if got, want := issue.Author.Avatar, "https://avatars3.githubusercontent.com/u/583231?v=4"; got != want {
-			t.Errorf("Want issue Author Name %q, got %q", want, got)
+			t.Errorf("Want issue Author Avatar %q, got %q", want, got)
 		}
 		if got, want := issue.Closed, false; got != want {
 			t.Errorf("Want issue Closed %v, got %v", want, got)
@@ -134,9 +134,6 @@ func testIssueComment(comment *scm.Comment) func(t *testing.T) {
 		}
 		if got, want := comment.Author.Login, "defualt"; got != want {
 			t.Errorf("Want issue comment Author Login %q, got %q", want, got)
-		}
-		if got, want := comment.Author.Avatar, "https://avatars2.githubusercontent.com/u/399135?v=4"; got != want {
-			t.Errorf("Want issue comment Author Name %q, got %q", want, got)
 		}
 		if got, want := comment.Created.Unix(), int64(1495732818); got != want {
 			t.Errorf("Want issue comment Created %d, got %d", want, got)

--- a/scm/driver/github/integration/pr_test.go
+++ b/scm/driver/github/integration/pr_test.go
@@ -185,9 +185,6 @@ func testPullRequestComment(comment *scm.Comment) func(t *testing.T) {
 		if got, want := comment.Author.Name, ""; got != want {
 			t.Errorf("Want pr comment Author Name %q, got %q", want, got)
 		}
-		if got, want := comment.Author.Avatar, "https://avatars3.githubusercontent.com/u/7744744?v=4"; got != want {
-			t.Errorf("Want pr comment Author Avatar %q, got %q", want, got)
-		}
 		if got, want := comment.Created.Unix(), int64(1414224391); got != want {
 			t.Errorf("Want pr comment Created %d, got %d", want, got)
 		}


### PR DESCRIPTION
GitHub would return different avatar URLs when using different endpoints (for
`Find` and `List`) to query issue and PR comments. This patch removes the
avatar URL checks to fix the integration test failures.

Original failures:
```
--- FAIL: TestGitLab (0.00s)
    --- FAIL: TestGitLab/PullRequests (0.00s)
        --- FAIL: TestGitLab/PullRequests/Comments (0.00s)
            --- FAIL: TestGitLab/PullRequests/Comments/List (0.22s)
                --- FAIL: TestGitLab/PullRequests/Comments/List/Comment (0.00s)
                    pr_test.go:189: Want pr comment Author Avatar "https://avatars3.githubusercontent.com/u/7744744?v=4", got "https://avatars1.githubusercontent.com/u/7744744?u=1298a2a920c277087962d56eef4507b124a73eea&v=4"
    --- FAIL: TestGitLab/Issues (0.95s)
        --- FAIL: TestGitLab/Issues/Comments (0.95s)
            --- FAIL: TestGitLab/Issues/Comments/Find (0.20s)
                --- FAIL: TestGitLab/Issues/Comments/Find/Comment (0.00s)
                    issue_test.go:139: Want issue comment Author Name "https://avatars2.githubusercontent.com/u/399135?v=4", got "https://avatars1.githubusercontent.com/u/399135?u=9f31d697670f39c7c9e5c2b43f7cf4ab15e5e54f&v=4"
```