### PR TITLE
Add support for commit list in push webhook

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/h2non/gock v1.0.9 h1:17gCehSo8ZOgEsFKpQgqHiR7VLyjxdAG3lkhVvO9QZU=
 github.com/h2non/gock v1.0.9/go.mod h1:CZMcB0Lg5IWnr9bF79pPMg9WeV6WumxQiUJ1UvdO1iE=

--- a/scm/driver/bitbucket/testdata/webhooks/push.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push.json.golden
@@ -33,6 +33,27 @@
         },
         "Link": "https://bitbucket.org/brydzewski/foo/commits/141977fedf5cf35aa290ac87d4b5177ac4cd9de1"
     },
+    "Commits": [
+        {
+            "Sha": "141977fedf5cf35aa290ac87d4b5177ac4cd9de1",
+            "Message": "Update README\n",
+            "Author": {
+                "Name": "Brad Rydzewski",
+                "Email": "brad.rydzewski@gmail.com",
+                "Date": "2018-07-02T20:26:56Z",
+                "Login": "brydzewski",
+                "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/"
+            },
+            "Committer": {
+                "Name": "Brad Rydzewski",
+                "Email": "brad.rydzewski@gmail.com",
+                "Date": "2018-07-02T20:26:56Z",
+                "Login": "brydzewski",
+                "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/"
+            },
+            "Link": "https://bitbucket.org/brydzewski/foo/commits/141977fedf5cf35aa290ac87d4b5177ac4cd9de1"
+        }
+    ],
     "Sender": {
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",

--- a/scm/driver/bitbucket/testdata/webhooks/push_branch_create.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_branch_create.json.golden
@@ -32,6 +32,46 @@
         },
         "Link": "https://bitbucket.org/brydzewski/foo/commits/141977fedf5cf35aa290ac87d4b5177ac4cd9de1"
     },
+    "Commits": [
+        {
+            "Sha": "141977fedf5cf35aa290ac87d4b5177ac4cd9de1",
+            "Message": "Update README\n",
+            "Author": {
+                "Name": "Brad Rydzewski",
+                "Email": "brad.rydzewski@gmail.com",
+                "Date": "2018-07-02T20:26:56Z",
+                "Login": "brydzewski",
+                "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/"
+            },
+            "Committer": {
+                "Name": "Brad Rydzewski",
+                "Email": "brad.rydzewski@gmail.com",
+                "Date": "2018-07-02T20:26:56Z",
+                "Login": "brydzewski",
+                "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/"
+            },
+            "Link": "https://bitbucket.org/brydzewski/foo/commits/141977fedf5cf35aa290ac87d4b5177ac4cd9de1"
+        },
+        {
+            "Sha": "40e7580cf11311d84a6e5e97e2cbba6df1675750",
+            "Message": "initial commit\n",
+            "Author": {
+                "Name": "Brad Rydzewski",
+                "Email": "brad.rydzewski@gmail.com",
+                "Date": "2018-07-02T20:22:41Z",
+                "Login": "brydzewski",
+                "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/"
+            },
+            "Committer": {
+                "Name": "Brad Rydzewski",
+                "Email": "brad.rydzewski@gmail.com",
+                "Date": "2018-07-02T20:22:41Z",
+                "Login": "brydzewski",
+                "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/"
+            },
+            "Link": "https://bitbucket.org/brydzewski/foo/commits/40e7580cf11311d84a6e5e97e2cbba6df1675750"
+        }
+    ],
     "Sender": {
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",

--- a/scm/driver/bitbucket/webhook.go
+++ b/scm/driver/bitbucket/webhook.go
@@ -389,6 +389,29 @@ type (
 
 func convertPushHook(src *pushHook) *scm.PushHook {
 	change := src.Push.Changes[0]
+	var commits []scm.Commit
+	for _, c := range change.Commits {
+		commits = append(commits,
+			scm.Commit{
+				Sha:     c.Hash,
+				Message: c.Message,
+				Link:    c.Links.HTML.Href,
+				Author: scm.Signature{
+					Login:  c.Author.User.Username,
+					Email:  extractEmail(c.Author.Raw),
+					Name:   c.Author.User.DisplayName,
+					Avatar: c.Author.User.Links.Avatar.Href,
+					Date:   c.Date,
+				},
+				Committer: scm.Signature{
+					Login:  c.Author.User.Username,
+					Email:  extractEmail(c.Author.Raw),
+					Name:   c.Author.User.DisplayName,
+					Avatar: c.Author.User.Links.Avatar.Href,
+					Date:   c.Date,
+				},
+			})
+	}
 	namespace, name := scm.Split(src.Repository.FullName)
 	dst := &scm.PushHook{
 		Ref:    scm.ExpandRef(change.New.Name, "refs/heads/"),
@@ -426,6 +449,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
+		Commits: commits,
 	}
 	if change.New.Type == "tag" {
 		dst.Ref = scm.ExpandRef(change.New.Name, "refs/tags/")

--- a/scm/driver/gitea/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/push.json.golden
@@ -33,6 +33,27 @@
     },
     "Link": "http://try.gitea.io/gogits/hello-world/compare/9836a96a253cce25d17988fcf41b8c4205cf779f...4522cbcefc20728a5b72b3a86af35e608622c514"
   },
+  "Commits": [
+    {
+      "Sha": "4522cbcefc20728a5b72b3a86af35e608622c514",
+      "Message": "Updated readme\n",
+      "Author": {
+        "Name": "Unknwon",
+        "Email": "noreply@gogs.io",
+        "Date": "2017-12-09T01:35:07Z",
+        "Login": "unknwon",
+        "Avatar": ""
+      },
+      "Committer": {
+        "Name": "Unknwon",
+        "Email": "noreply@gogs.io",
+        "Date": "2017-12-09T01:35:07Z",
+        "Login": "unknwon",
+        "Avatar": ""
+      },
+      "Link": "http://try.gitea.io/gogits/hello-world/commit/4522cbcefc20728a5b72b3a86af35e608622c514"
+    }
+  ],
   "Sender": {
     "Login": "unknwon",
     "Name": "",

--- a/scm/driver/gitea/webhook.go
+++ b/scm/driver/gitea/webhook.go
@@ -208,6 +208,28 @@ func convertBranchHook(dst *createHook, action scm.Action) *scm.BranchHook {
 
 func convertPushHook(dst *pushHook) *scm.PushHook {
 	if len(dst.Commits) > 0 {
+		var commits []scm.Commit
+		for _, c := range dst.Commits {
+			commits = append(commits,
+				scm.Commit{
+					Sha:     c.ID,
+					Message: c.Message,
+					Link:    c.URL,
+					Author: scm.Signature{
+						Login: c.Author.Username,
+						Email: c.Author.Email,
+						Name:  c.Author.Name,
+						Date:  c.Timestamp,
+					},
+					Committer: scm.Signature{
+						Login: c.Committer.Username,
+						Email: c.Committer.Email,
+						Name:  c.Committer.Name,
+						Date:  c.Timestamp,
+					},
+				})
+		}
+
 		return &scm.PushHook{
 			Ref:    dst.Ref,
 			Before: dst.Before,
@@ -228,8 +250,9 @@ func convertPushHook(dst *pushHook) *scm.PushHook {
 					Date:  dst.Commits[0].Timestamp,
 				},
 			},
-			Repo:   *convertRepository(&dst.Repository),
-			Sender: *convertUser(&dst.Sender),
+			Commits: commits,
+			Repo:    *convertRepository(&dst.Repository),
+			Sender:  *convertUser(&dst.Sender),
 		}
 	} else {
 		return &scm.PushHook{

--- a/scm/driver/github/testdata/webhooks/push.json.golden
+++ b/scm/driver/github/testdata/webhooks/push.json.golden
@@ -34,6 +34,27 @@
     },
     "Link": "https://github.com/Codertocat/Hello-World/compare/a10867b14bb7...000000000000"
   },
+  "Commits": [
+    {
+      "Sha": "199eddf46df50de8d02e99bf1c5fdb4101338224",
+      "Message": "Update README",
+      "Author": {
+        "Name": "Codertocat",
+        "Email": "21031067+Codertocat@users.noreply.github.com",
+        "Date": "2018-06-15T13:01:51-07:00",
+        "Login": "Codertocat",
+        "Avatar": ""
+      },
+      "Committer": {
+        "Name": "GitHub",
+        "Email": "noreply@github.com",
+        "Date": "2018-06-15T13:01:51-07:00",
+        "Login": "web-flow",
+        "Avatar": ""
+      },
+      "Link": "https://github.com/Codertocat/Hello-World/compare/199eddf46df50de8d02e99bf1c5fdb4101338224"
+    }
+  ],
   "Sender": {
     "Login": "Codertocat",
     "Name": "",

--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -260,6 +260,27 @@ type (
 //
 
 func convertPushHook(src *pushHook) *scm.PushHook {
+	var commits []scm.Commit
+	for _, c := range src.Commits {
+		commits = append(commits,
+			scm.Commit{
+				Sha:     c.ID,
+				Message: c.Message,
+				Link:    c.URL,
+				Author: scm.Signature{
+					Login: c.Author.Username,
+					Email: c.Author.Email,
+					Name:  c.Author.Name,
+					Date:  c.Timestamp.ValueOrZero(),
+				},
+				Committer: scm.Signature{
+					Login: c.Committer.Username,
+					Email: c.Committer.Email,
+					Name:  c.Committer.Name,
+					Date:  c.Timestamp.ValueOrZero(),
+				},
+			})
+	}
 	dst := &scm.PushHook{
 		Ref:     src.Ref,
 		BaseRef: src.BaseRef,
@@ -293,6 +314,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 			Link:      src.Repository.HTMLURL,
 		},
 		Sender: *convertUser(&src.Sender),
+		Commits: commits,
 	}
 	// fix https://github.com/drone/go-scm/issues/8
 	if scm.IsTag(dst.Ref) && src.Head.ID != "" {

--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -313,7 +313,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 			CloneSSH:  src.Repository.SSHURL,
 			Link:      src.Repository.HTMLURL,
 		},
-		Sender: *convertUser(&src.Sender),
+		Sender:  *convertUser(&src.Sender),
 		Commits: commits,
 	}
 	// fix https://github.com/drone/go-scm/issues/8

--- a/scm/driver/gitlab/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/branch_create.json.golden
@@ -32,6 +32,27 @@
         },
         "Link": "https://gitlab.com/gitlab-org/hello-world/commit/c4c79227ed610f1151f05bbc5be33b4f340d39c8"
     },
+    "Commits": [
+        {
+            "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
+            "Message": "update readme\n",
+            "Author": {
+                "Name": "Sid Sijbrandij",
+                "Email": "noreply@gitlab.com",
+                "Date": "0001-01-01T00:00:00Z",
+                "Login": "",
+                "Avatar": ""
+            },
+            "Committer": {
+                "Name": "Sid Sijbrandij",
+                "Email": "noreply@gitlab.com",
+                "Date": "0001-01-01T00:00:00Z",
+                "Login": "",
+                "Avatar": ""
+            },
+            "Link": "https://gitlab.com/gitlab-org/hello-world/commit/c4c79227ed610f1151f05bbc5be33b4f340d39c8"
+        }
+    ],
     "Sender": {
         "Login": "sytses",
         "Name": "Sid Sijbrandij",

--- a/scm/driver/gitlab/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/push.json.golden
@@ -32,6 +32,27 @@
         },
         "Link": "https://gitlab.com/gitlab-org/hello-world/commit/2adc9465c4edfc33834e173fe89436a7cb899a1d"
     },
+    "Commits": [
+        {
+            "Sha": "2adc9465c4edfc33834e173fe89436a7cb899a1d",
+            "Message": "added readme\n",
+            "Author": {
+                "Name": "Sid Sijbrandij",
+                "Email": "noreply@gitlab.com",
+                "Date": "0001-01-01T00:00:00Z",
+                "Login": "",
+                "Avatar": ""
+            },
+            "Committer": {
+                "Name": "Sid Sijbrandij",
+                "Email": "noreply@gitlab.com",
+                "Date": "0001-01-01T00:00:00Z",
+                "Login": "",
+                "Avatar": ""
+            },
+            "Link": "https://gitlab.com/gitlab-org/hello-world/commit/2adc9465c4edfc33834e173fe89436a7cb899a1d"
+        }
+    ],
     "Sender": {
         "Login": "sytses",
         "Name": "Sid Sijbrandij",

--- a/scm/driver/gitlab/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/tag_create.json.golden
@@ -32,6 +32,27 @@
         },
         "Link": "https://gitlab.com/gitlab-org/hello-world/commit/2adc9465c4edfc33834e173fe89436a7cb899a1d"
     },
+    "Commits": [
+        {
+            "Sha": "2adc9465c4edfc33834e173fe89436a7cb899a1d",
+            "Message": "added readme\n",
+            "Author": {
+                "Name": "Sid Sijbrandij",
+                "Email": "noreply@gitlab.com",
+                "Date": "0001-01-01T00:00:00Z",
+                "Login": "",
+                "Avatar": ""
+            },
+            "Committer": {
+                "Name": "Sid Sijbrandij",
+                "Email": "noreply@gitlab.com",
+                "Date": "0001-01-01T00:00:00Z",
+                "Login": "",
+                "Avatar": ""
+            },
+            "Link": "https://gitlab.com/gitlab-org/hello-world/commit/2adc9465c4edfc33834e173fe89436a7cb899a1d"
+        }
+    ],
     "Sender": {
         "Login": "sytses",
         "Name": "Sid Sijbrandij",

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -104,6 +104,23 @@ func parsePullRequestHook(data []byte) (scm.Webhook, error) {
 }
 
 func convertPushHook(src *pushHook) *scm.PushHook {
+	var commits []scm.Commit
+	for _, c := range src.Commits {
+		commits = append(commits,
+			scm.Commit{
+				Sha:     c.ID,
+				Message: c.Message,
+				Link:    c.URL,
+				Author: scm.Signature{
+					Name:  c.Author.Name,
+					Email: c.Author.Email,
+				},
+				Committer: scm.Signature{
+					Name:  c.Author.Name,
+					Email: c.Author.Email,
+				},
+			})
+	}
 	namespace, name := scm.Split(src.Project.PathWithNamespace)
 	dst := &scm.PushHook{
 		Ref: scm.ExpandRef(src.Ref, "refs/heads/"),
@@ -140,6 +157,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 			Email:  src.UserEmail,
 			Avatar: src.UserAvatar,
 		},
+		Commits: commits,
 	}
 	if len(src.Commits) > 0 {
 		// get the last commit (most recent)

--- a/scm/driver/gogs/testdata/webhooks/push.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/push.json.golden
@@ -32,6 +32,27 @@
     },
     "Link": "http://try.gogs.io/gogits/hello-world/compare/9836a96a253cce25d17988fcf41b8c4205cf779f...4522cbcefc20728a5b72b3a86af35e608622c514"
   },
+  "Commits": [
+    {
+      "Sha": "4522cbcefc20728a5b72b3a86af35e608622c514",
+      "Message": "Updated readme\n",
+      "Author": {
+        "Name": "Unknwon",
+        "Email": "noreply@gogs.io",
+        "Date": "2017-12-09T01:35:07Z",
+        "Login": "unknwon",
+        "Avatar": ""
+      },
+      "Committer": {
+        "Name": "Unknwon",
+        "Email": "noreply@gogs.io",
+        "Date": "2017-12-09T01:35:07Z",
+        "Login": "unknwon",
+        "Avatar": ""
+      },
+      "Link": "http://try.gogs.io/gogits/hello-world/commit/4522cbcefc20728a5b72b3a86af35e608622c514"
+    }
+  ],
   "Sender": {
     "Login": "unknwon",
     "Name": "",

--- a/scm/driver/gogs/webhook.go
+++ b/scm/driver/gogs/webhook.go
@@ -198,6 +198,27 @@ func convertBranchHook(dst *createHook, action scm.Action) *scm.BranchHook {
 }
 
 func convertPushHook(dst *pushHook) *scm.PushHook {
+	var commits []scm.Commit
+	for _, c := range dst.Commits {
+		commits = append(commits,
+			scm.Commit{
+				Sha:     c.ID,
+				Message: c.Message,
+				Link:    c.URL,
+				Author: scm.Signature{
+					Login: c.Author.Username,
+					Email: c.Author.Email,
+					Name:  c.Author.Name,
+					Date:  c.Timestamp,
+				},
+				Committer: scm.Signature{
+					Login: c.Committer.Username,
+					Email: c.Committer.Email,
+					Name:  c.Committer.Name,
+					Date:  c.Timestamp,
+				},
+			})
+	}
 	return &scm.PushHook{
 		Ref: scm.ExpandRef(dst.Ref, "refs/heads/"),
 		Commit: scm.Commit{
@@ -217,8 +238,9 @@ func convertPushHook(dst *pushHook) *scm.PushHook {
 				Date:  dst.Commits[0].Timestamp,
 			},
 		},
-		Repo:   *convertRepository(&dst.Repository),
-		Sender: *convertUser(&dst.Sender),
+		Repo:    *convertRepository(&dst.Repository),
+		Sender:  *convertUser(&dst.Sender),
+		Commits: commits,
 	}
 }
 

--- a/scm/driver/stash/testdata/webhooks/push.json.golden
+++ b/scm/driver/stash/testdata/webhooks/push.json.golden
@@ -36,20 +36,6 @@
         {
             "Sha": "823b2230a56056231c9425d63758fa87078a66b4",
             "Message": "",
-            "Author": {
-                "Name": "Jane Citizen",
-                "Email": "jane@example.com",
-                "Date": "2018-07-05T18:22:00Z",
-                "Login": "jcitizen",
-                "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
-            },
-            "Committer": {
-                "Name": "Jane Citizen",
-                "Email": "jane@example.com",
-                "Date": "2018-07-05T18:22:00Z",
-                "Login": "jcitizen",
-                "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
-            },
             "Link": ""
         }
     ], 

--- a/scm/driver/stash/testdata/webhooks/push.json.golden
+++ b/scm/driver/stash/testdata/webhooks/push.json.golden
@@ -32,6 +32,27 @@
         },
         "Link": ""
     },
+    "Commits": [
+        {
+            "Sha": "823b2230a56056231c9425d63758fa87078a66b4",
+            "Message": "",
+            "Author": {
+                "Name": "Jane Citizen",
+                "Email": "jane@example.com",
+                "Date": "2018-07-05T18:22:00Z",
+                "Login": "jcitizen",
+                "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
+            },
+            "Committer": {
+                "Name": "Jane Citizen",
+                "Email": "jane@example.com",
+                "Date": "2018-07-05T18:22:00Z",
+                "Login": "jcitizen",
+                "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
+            },
+            "Link": ""
+        }
+    ], 
     "Sender": {
         "Login": "jcitizen",
         "Name": "Jane Citizen",

--- a/scm/driver/stash/webhook.go
+++ b/scm/driver/stash/webhook.go
@@ -156,11 +156,9 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 	for _, c := range src.Changes {
 		commits = append(commits,
 			scm.Commit{
-				Sha:       c.ToHash,
-				Message:   "",
-				Link:      "",
-				Author:    signer,
-				Committer: signer,
+				Sha:     c.ToHash,
+				Message: "",
+				Link:    "",
 			})
 	}
 	return &scm.PushHook{

--- a/scm/driver/stash/webhook.go
+++ b/scm/driver/stash/webhook.go
@@ -151,6 +151,18 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 	sender := convertUser(src.Actor)
 	signer := convertSignature(src.Actor)
 	signer.Date, _ = time.Parse("2006-01-02T15:04:05+0000", src.Date)
+
+	var commits []scm.Commit
+	for _, c := range src.Changes {
+		commits = append(commits,
+			scm.Commit{
+				Sha:       c.ToHash,
+				Message:   "",
+				Link:      "",
+				Author:    signer,
+				Committer: signer,
+			})
+	}
 	return &scm.PushHook{
 		Ref: change.RefID,
 		Commit: scm.Commit{
@@ -160,8 +172,9 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 			Author:    signer,
 			Committer: signer,
 		},
-		Repo:   *repo,
-		Sender: *sender,
+		Repo:    *repo,
+		Sender:  *sender,
+		Commits: commits,
 	}
 }
 

--- a/scm/webhook.go
+++ b/scm/webhook.go
@@ -34,6 +34,7 @@ type (
 		After   string
 		Commit  Commit
 		Sender  User
+		Commits []Commit
 	}
 
 	// BranchHook represents a branch or tag event,


### PR DESCRIPTION
This patch adds support for commits in push web hook for GitHub, bitbucket, gitlab, gogs, stash and gitea