### PR TITLE
Add github ping hook handler

### DIFF
--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -442,7 +442,6 @@ func convertDeploymentHook(src *deploymentHook) *scm.DeployHook {
 
 func convertPingHook(src *pingHook) *scm.PingHook {
 	return &scm.PingHook{
-		// Action        Action
 		Repo: scm.Repository{
 			ID:        fmt.Sprint(src.Repository.ID),
 			Namespace: src.Repository.Owner.Login,

--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -41,6 +41,8 @@ func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhoo
 		hook, err = s.parsePullRequestHook(data)
 	case "deployment":
 		hook, err = s.parseDeploymentHook(data)
+	case "ping":
+		hook, err = s.parsePingHook(data)
 	// case "pull_request_review_comment":
 	// case "issues":
 	// case "issue_comment":
@@ -147,6 +149,18 @@ func (s *webhookService) parsePullRequestHook(data []byte) (scm.Webhook, error) 
 	return dst, nil
 }
 
+func (s *webhookService) parsePingHook(data []byte) (scm.Webhook, error) {
+	src := new(pingHook)
+	err := json.Unmarshal(data, src)
+
+	if err != nil {
+		return nil, err
+	}
+	dst := convertPingHook(src)
+	return dst, nil
+
+}
+
 //
 // native data structures
 //
@@ -234,6 +248,11 @@ type (
 		PullRequest pr         `json:"pull_request"`
 		Repository  repository `json:"repository"`
 		Sender      user       `json:"sender"`
+	}
+
+	pingHook struct {
+		Repository repository `json:"repository"`
+		Sender     user       `json:"sender"`
 	}
 
 	// github deployment webhook payload
@@ -419,6 +438,23 @@ func convertDeploymentHook(src *deploymentHook) *scm.DeployHook {
 		dst.Ref.Path = scm.ExpandRef(dst.Ref.Path, "refs/heads/")
 	}
 	return dst
+}
+
+func convertPingHook(src *pingHook) *scm.PingHook {
+	return &scm.PingHook{
+		// Action        Action
+		Repo: scm.Repository{
+			ID:        fmt.Sprint(src.Repository.ID),
+			Namespace: src.Repository.Owner.Login,
+			Name:      src.Repository.Name,
+			Branch:    src.Repository.DefaultBranch,
+			Private:   src.Repository.Private,
+			Clone:     src.Repository.CloneURL,
+			CloneSSH:  src.Repository.SSHURL,
+			Link:      src.Repository.HTMLURL,
+		},
+		Sender: *convertUser(&src.Sender),
+	}
 }
 
 // regexp help determine if the named git object is a tag.

--- a/scm/webhook.go
+++ b/scm/webhook.go
@@ -115,6 +115,12 @@ type (
 		Task      string
 	}
 
+	// PingHook represents a ping hook, eg ping events.
+	PingHook struct {
+		Repo   Repository
+		Sender User
+	}
+
 	// SecretFunc provides the Webhook parser with the
 	// secret key used to validate webhook authenticity.
 	SecretFunc func(webhook Webhook) (string, error)
@@ -140,3 +146,4 @@ func (h *IssueCommentHook) Repository() Repository       { return h.Repo }
 func (h *PullRequestHook) Repository() Repository        { return h.Repo }
 func (h *PullRequestCommentHook) Repository() Repository { return h.Repo }
 func (h *ReviewCommentHook) Repository() Repository      { return h.Repo }
+func (h *PingHook) Repository() Repository               { return h.Repo }


### PR DESCRIPTION
When creating a new webhook GitHub sends the ping event to see if the setup is done properly. Currently, the ping is not handled, and on receiving the ping event `Unknown webhook event`.