### PR TITLE
Implemented FindTag for github driver.

### DIFF
--- a/scm/driver/github/testdata/tag.json
+++ b/scm/driver/github/testdata/tag.json
@@ -1,0 +1,10 @@
+{
+    "ref": "refs/tags/v0.1",
+    "node_id": "MDY6Q29tbWl0MTI5NjI2OTo3ZmQxYTYwYjAxZjkxYjMxNGY1OTk1NWE0ZTRkNGU4MGQ4ZWRmMTFk",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/refs/tags/v0.1",
+    "object": {
+        "sha": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+        "type": "commit",
+        "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
+    }
+}

--- a/scm/driver/github/testdata/tag.json.golden
+++ b/scm/driver/github/testdata/tag.json.golden
@@ -1,0 +1,5 @@
+{
+    "Name": "v0.1",
+    "Path": "refs/tags/v0.1",
+    "Sha": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
+}


### PR DESCRIPTION
GitHub API doesn't have a `/repo/{owner}/{repo}/tags/{tag}` endpoint. However, it does have [Git database](https://docs.github.com/en/free-pro-team@latest/rest/reference/git) API, which provides the `/repo/{owner}/{repo}/git/ref/tags/{tag}` endpoint. This PR implements `FindTag` with this API endpoint.