### PR TITLE
add Files to scm.Commit

### DIFF
--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -126,10 +126,20 @@ func convertCommitList(from []*commit) []*scm.Commit {
 }
 
 func convertCommit(from *commit) *scm.Commit {
+	var files []scm.File
+	for _, file := range from.Files {
+		files = append(files, scm.File{
+			Filename: file.Filename,
+			Sha:      file.Sha,
+			Status:   file.Status,
+		})
+	}
+
 	return &scm.Commit{
 		Message: from.Commit.Message,
 		Sha:     from.Sha,
 		Link:    from.URL,
+		Files:   files,
 		Author: scm.Signature{
 			Name:   from.Commit.Author.Name,
 			Email:  from.Commit.Author.Email,

--- a/scm/driver/github/testdata/commit.json.golden
+++ b/scm/driver/github/testdata/commit.json.golden
@@ -15,5 +15,12 @@
         "Login": "octocat",
         "Avatar": "https://avatars3.githubusercontent.com/u/583231?v=4"
     },
-    "Link": "https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
+    "Link": "https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+    "Files": [
+        {
+            "Filename": "file1.txt",
+            "Sha": "bbcd538c8e72b8c175046e27cc8f907076331401",
+            "Status": "added"
+        }
+    ]
 }

--- a/scm/git.go
+++ b/scm/git.go
@@ -27,6 +27,7 @@ type (
 		Author    Signature
 		Committer Signature
 		Link      string
+		Files     []File
 	}
 
 	// CommitListOptions provides options for querying a
@@ -35,6 +36,12 @@ type (
 		Ref  string
 		Page int
 		Size int
+	}
+
+	File struct {
+		Filename string
+		Sha      string
+		Status   string
 	}
 
 	// Signature identifies a git commit creator.


### PR DESCRIPTION
the list of files changed will be useful when taking action based on files
changed

this will hopefully handle https://github.com/drone/go-scm/issues/80 and let https://github.com/meltwater/drone-convert-pathschanged use this module rather than its own logic

it is unclear to me if changing `scm.Commit` will affect other non-github drivers, but since `FindCommit` calls `convertCommit`, which returns `*scm.Commit`, I can't see a way around it