### PR TITLE
Added before and after values to show before and after commitids on push

### DIFF
--- a/scm/driver/stash/testdata/webhooks/push.json.golden
+++ b/scm/driver/stash/testdata/webhooks/push.json.golden
@@ -1,5 +1,7 @@
 {
     "Ref": "refs/heads/master",
+    "After": "823b2230a56056231c9425d63758fa87078a66b4",
+    "Before": "5c64a07cd6c0f21b753bf261ef059c7e7633c50a",
     "Repo": {
         "ID": "1",
         "Namespace": "PRJ",

--- a/scm/driver/stash/webhook.go
+++ b/scm/driver/stash/webhook.go
@@ -163,6 +163,8 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 	}
 	return &scm.PushHook{
 		Ref: change.RefID,
+		After: change.ToHash,
+		Before: change.FromHash,
 		Commit: scm.Commit{
 			Sha:       change.ToHash,
 			Message:   "",


### PR DESCRIPTION
After and Before values are needed for example in paths plugin where multiple commits are done before push event.