### PR TITLE
use access json header / extend error message parsing for stash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.out
 _*.md
 .vscode
+.idea
 cmd


### PR DESCRIPTION
As found in https://discourse.drone.io/t/panic-or-undefined-error-when-create-build-from-bitbucket-repository/8549/3

Somehow Bitbucket server does not always return a list of Errors, but only one message with status code.

This PR uses this rool-level message as error if present if the error list is empty.

It also sets the "Accept: application/json" header on the request, since the following code expects the response to be json.