### PR TITLE
[CI-0]: Added Pr in issue

### DIFF
--- a/scm/driver/github/issue.go
+++ b/scm/driver/github/issue.go
@@ -91,13 +91,14 @@ func (s *issueService) Unlock(ctx context.Context, repo string, number int) (*sc
 }
 
 type issue struct {
-	ID      int    `json:"id"`
-	HTMLURL string `json:"html_url"`
-	Number  int    `json:"number"`
-	State   string `json:"state"`
-	Title   string `json:"title"`
-	Body    string `json:"body"`
-	User    struct {
+	ID          int    `json:"id"`
+	HTMLURL     string `json:"html_url"`
+	Number      int    `json:"number"`
+	State       string `json:"state"`
+	Title       string `json:"title"`
+	Body        string `json:"body"`
+	PullRequest pr     `json:"pull_request"`
+	User        struct {
 		Login     string `json:"login"`
 		AvatarURL string `json:"avatar_url"`
 	} `json:"user"`
@@ -150,6 +151,10 @@ func convertIssue(from *issue) *scm.Issue {
 		Body:   from.Body,
 		Link:   from.HTMLURL,
 		Labels: convertLabels(from),
+		PullRequest: scm.PullRequest{
+			Diff: from.PullRequest.DiffURL,
+			Link: from.PullRequest.HTMLURL,
+		},
 		Locked: from.Locked,
 		Closed: from.State == "closed",
 		Author: scm.User{

--- a/scm/driver/github/issue_test.go
+++ b/scm/driver/github/issue_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/drone/go-scm/scm"
@@ -104,6 +105,10 @@ func TestIssueList(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
+
+		// debug only. remove once implemented
+		json.NewEncoder(os.Stdout).Encode(want)
+		json.NewEncoder(os.Stdout).Encode(got)
 	}
 
 	t.Run("Request", testRequest(res))

--- a/scm/driver/github/issue_test.go
+++ b/scm/driver/github/issue_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/drone/go-scm/scm"
@@ -105,10 +104,6 @@ func TestIssueList(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
-
-		// debug only. remove once implemented
-		json.NewEncoder(os.Stdout).Encode(want)
-		json.NewEncoder(os.Stdout).Encode(got)
 	}
 
 	t.Run("Request", testRequest(res))

--- a/scm/driver/github/testdata/issue.json.golden
+++ b/scm/driver/github/testdata/issue.json.golden
@@ -15,5 +15,9 @@
         "Avatar": "https://github.com/images/error/octocat_happy.gif"
     },
     "Created": "2011-04-22T13:33:48Z",
-    "Updated": "2011-04-22T13:33:48Z"
+    "Updated": "2011-04-22T13:33:48Z",
+	"PullRequest": {
+		"Link": "https://github.com/octocat/Hello-World/pull/1347",
+		"Diff": "https://github.com/octocat/Hello-World/pull/1347.diff"
+	}
 }

--- a/scm/driver/github/testdata/issue.json.golden
+++ b/scm/driver/github/testdata/issue.json.golden
@@ -16,8 +16,8 @@
     },
     "Created": "2011-04-22T13:33:48Z",
     "Updated": "2011-04-22T13:33:48Z",
-	"PullRequest": {
-		"Link": "https://github.com/octocat/Hello-World/pull/1347",
-		"Diff": "https://github.com/octocat/Hello-World/pull/1347.diff"
-	}
+    "PullRequest": {
+        "Link": "https://github.com/octocat/Hello-World/pull/1347",
+        "Diff": "https://github.com/octocat/Hello-World/pull/1347.diff"
+    }
 }

--- a/scm/driver/github/testdata/issues.json.golden
+++ b/scm/driver/github/testdata/issues.json.golden
@@ -16,6 +16,10 @@
             "Avatar": "https://github.com/images/error/octocat_happy.gif"
         },
         "Created": "2011-04-22T13:33:48Z",
-        "Updated": "2011-04-22T13:33:48Z"
+        "Updated": "2011-04-22T13:33:48Z",
+        "PullRequest": {
+            "Link": "https://github.com/octocat/Hello-World/pull/1347",
+            "Diff": "https://github.com/octocat/Hello-World/pull/1347.diff"
+        }
     }
 ]

--- a/scm/driver/github/testdata/webhooks/comment.json.golden
+++ b/scm/driver/github/testdata/webhooks/comment.json.golden
@@ -31,39 +31,8 @@
          "Updated":"0001-01-01T00:00:00Z"
       },
       "PullRequest":{
-         "Number":0,
-         "Title":"",
-         "Body":"",
-         "Sha":"",
-         "Ref":"",
-         "Source":"",
-         "Target":"",
-         "Fork":"",
          "Link":"https://github.com/abc/def-ci-webhook-test/pull/2",
-         "Diff":"https://github.com/abc/def-ci-webhook-test/pull/2.diff",
-         "Closed":false,
-         "Merged":false,
-         "Base":{
-            "Name":"",
-            "Path":"",
-            "Sha":""
-         },
-         "Head":{
-            "Name":"",
-            "Path":"",
-            "Sha":""
-         },
-         "Author":{
-            "Login":"",
-            "Name":"",
-            "Email":"",
-            "Avatar":"",
-            "Created":"0001-01-01T00:00:00Z",
-            "Updated":"0001-01-01T00:00:00Z"
-         },
-         "Created":"0001-01-01T00:00:00Z",
-         "Updated":"0001-01-01T00:00:00Z",
-         "Labels":null
+         "Diff":"https://github.com/abc/def-ci-webhook-test/pull/2.diff"
       },
       "Created":"2020-11-03T22:32:14Z",
       "Updated":"2020-12-29T05:49:14Z"

--- a/scm/driver/github/testdata/webhooks/comment.json.golden
+++ b/scm/driver/github/testdata/webhooks/comment.json.golden
@@ -1,58 +1,93 @@
 {
-	"Action": "created",
-	"Repo": {
-		"ID": "309651765",
-		"Namespace": "abc",
-		"Name": "def-ci-webhook-test",
-		"Perm": null,
-		"Branch": "master",
-		"Private": true,
-		"Visibility": 0,
-		"Clone": "https://github.com/abc/def-ci-webhook-test.git",
-		"CloneSSH": "git@github.com:abc/def-ci-webhook-test.git",
-		"Link": "https://github.com/abc/def-ci-webhook-test",
-		"Created": "0001-01-01T00:00:00Z",
-		"Updated": "0001-01-01T00:00:00Z"
-	},
-	"Issue": {
-		"Number": 2,
-		"Title": "Update README.md",
-		"Body": "",
-		"Link": "https://github.com/abc/def-ci-webhook-test/pull/2",
-		"Labels": null,
-		"Closed": false,
-		"Locked": false,
-		"Author": {
-			"Login": "lts-def",
-			"Name": "",
-			"Email": "",
-			"Avatar": "https://avatars0.githubusercontent.com/u/10278482?v=4",
-			"Created": "0001-01-01T00:00:00Z",
-			"Updated": "0001-01-01T00:00:00Z"
-		},
-		"Created": "2020-11-03T22:32:14Z",
-		"Updated": "2020-12-29T05:49:14Z"
-	},
-	"Comment": {
-		"ID": 751955664,
-		"Body": "trigger abc",
-		"Author": {
-			"Login": "lts-def",
-			"Name": "",
-			"Email": "",
-			"Avatar": "https://avatars0.githubusercontent.com/u/10278482?v=4",
-			"Created": "0001-01-01T00:00:00Z",
-			"Updated": "0001-01-01T00:00:00Z"
-		},
-		"Created": "2020-12-29T05:49:14Z",
-		"Updated": "2020-12-29T05:49:14Z"
-	},
-	"Sender": {
-		"Login": "lts-def",
-		"Name": "",
-		"Email": "",
-		"Avatar": "https://avatars0.githubusercontent.com/u/10278482?v=4",
-		"Created": "0001-01-01T00:00:00Z",
-		"Updated": "0001-01-01T00:00:00Z"
-	}
+   "Action":"created",
+   "Repo":{
+      "ID":"309651765",
+      "Namespace":"abc",
+      "Name":"def-ci-webhook-test",
+      "Perm":null,
+      "Branch":"master",
+      "Private":true,
+      "Visibility":0,
+      "Clone":"https://github.com/abc/def-ci-webhook-test.git",
+      "CloneSSH":"git@github.com:abc/def-ci-webhook-test.git",
+      "Link":"https://github.com/abc/def-ci-webhook-test",
+      "Created":"0001-01-01T00:00:00Z",
+      "Updated":"0001-01-01T00:00:00Z"
+   },
+   "Issue":{
+      "Number":2,
+      "Title":"Update README.md",
+      "Body":"",
+      "Link":"https://github.com/abc/def-ci-webhook-test/pull/2",
+      "Labels":null,
+      "Closed":false,
+      "Locked":false,
+      "Author":{
+         "Login":"lts-def",
+         "Name":"",
+         "Email":"",
+         "Avatar":"https://avatars0.githubusercontent.com/u/10278482?v=4",
+         "Created":"0001-01-01T00:00:00Z",
+         "Updated":"0001-01-01T00:00:00Z"
+      },
+      "PullRequest":{
+         "Number":0,
+         "Title":"",
+         "Body":"",
+         "Sha":"",
+         "Ref":"",
+         "Source":"",
+         "Target":"",
+         "Fork":"",
+         "Link":"https://github.com/abc/def-ci-webhook-test/pull/2",
+         "Diff":"https://github.com/abc/def-ci-webhook-test/pull/2.diff",
+         "Closed":false,
+         "Merged":false,
+         "Base":{
+            "Name":"",
+            "Path":"",
+            "Sha":""
+         },
+         "Head":{
+            "Name":"",
+            "Path":"",
+            "Sha":""
+         },
+         "Author":{
+            "Login":"",
+            "Name":"",
+            "Email":"",
+            "Avatar":"",
+            "Created":"0001-01-01T00:00:00Z",
+            "Updated":"0001-01-01T00:00:00Z"
+         },
+         "Created":"0001-01-01T00:00:00Z",
+         "Updated":"0001-01-01T00:00:00Z",
+         "Labels":null
+      },
+      "Created":"2020-11-03T22:32:14Z",
+      "Updated":"2020-12-29T05:49:14Z"
+   },
+   "Comment":{
+      "ID":751955664,
+      "Body":"trigger abc",
+      "Author":{
+         "Login":"lts-def",
+         "Name":"",
+         "Email":"",
+         "Avatar":"https://avatars0.githubusercontent.com/u/10278482?v=4",
+         "Created":"0001-01-01T00:00:00Z",
+         "Updated":"0001-01-01T00:00:00Z"
+      },
+      "Created":"2020-12-29T05:49:14Z",
+      "Updated":"2020-12-29T05:49:14Z"
+   },
+   "Sender":{
+      "Login":"lts-def",
+      "Name":"",
+      "Email":"",
+      "Avatar":"https://avatars0.githubusercontent.com/u/10278482?v=4",
+      "Created":"0001-01-01T00:00:00Z",
+      "Updated":"0001-01-01T00:00:00Z"
+   }
 }

--- a/scm/issue.go
+++ b/scm/issue.go
@@ -12,16 +12,17 @@ import (
 type (
 	// Issue represents an issue.
 	Issue struct {
-		Number  int
-		Title   string
-		Body    string
-		Link    string
-		Labels  []string
-		Closed  bool
-		Locked  bool
-		Author  User
-		Created time.Time
-		Updated time.Time
+		Number      int
+		Title       string
+		Body        string
+		Link        string
+		Labels      []string
+		Closed      bool
+		Locked      bool
+		Author      User
+		PullRequest PullRequest
+		Created     time.Time
+		Updated     time.Time
 	}
 
 	// IssueInput provides the input fields required for


### PR DESCRIPTION
Currently, there is no way to verify if a webhook coming from github is a comment on PR or a comment on an issue. The difference b/w the webhooks is that the latter one has `pull_request` key in it. We need to forward the info to scm.IssueCommentHook so that the downstram service can understand if which type of comment this is. 