### PR TITLE
Update GH list-commits parameter

### DIFF
--- a/scm/driver/github/git_test.go
+++ b/scm/driver/github/git_test.go
@@ -113,7 +113,7 @@ func TestGitListCommits(t *testing.T) {
 		Get("/repos/octocat/hello-world/commits").
 		MatchParam("page", "1").
 		MatchParam("per_page", "30").
-		MatchParam("ref", "master").
+		MatchParam("sha", "master").
 		Reply(200).
 		Type("application/json").
 		SetHeaders(mockHeaders).

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -31,7 +31,7 @@ func encodeCommitListOptions(opts scm.CommitListOptions) string {
 		params.Set("per_page", strconv.Itoa(opts.Size))
 	}
 	if opts.Ref != "" {
-		params.Set("ref", opts.Ref)
+		params.Set("sha", opts.Ref)
 	}
 	return params.Encode()
 }

--- a/scm/driver/github/util_test.go
+++ b/scm/driver/github/util_test.go
@@ -28,7 +28,7 @@ func Test_encodeCommitListOptions(t *testing.T) {
 		Size: 30,
 		Ref:  "master",
 	}
-	want := "page=10&per_page=30&ref=master"
+	want := "page=10&per_page=30&sha=master"
 	got := encodeCommitListOptions(opts)
 	if got != want {
 		t.Errorf("Want encoded commit list options %q, got %q", want, got)


### PR DESCRIPTION
Fixes: #76 

From local testing against GH api, it seems this change is still compatible with passing ref in the sha parameter (for example, branch name) 