### PR TITLE
Fixing Gitea commit API in case `ref/heads/` prefix is added to ref

### DIFF
--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -29,6 +29,7 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 }
 
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
+	ref = scm.TrimRef(ref)
 	path := fmt.Sprintf("api/v1/repos/%s/git/commits/%s", repo, url.PathEscape(ref))
 	out := new(commitInfo)
 	res, err := s.client.do(ctx, "GET", path, nil, out)


### PR DESCRIPTION
If `FindCommit` gets used with a branch name instead of a sha, it may include the `ref/heads/` prefix, and the resulting API path of `.../commits/ref%2Fheads%2Fmy-branch` will return a 404. Trimming off that prefix so it's just `.../commits/my-branch` correctly returns the expected commit data.