### PR TITLE
fix stash driver fetching repo permissions

### DIFF
--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -171,7 +171,7 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 // listWrite returns the user repository list.
 func (s *repositoryService) listWrite(ctx context.Context, repo string) ([]*scm.Repository, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
-	path := fmt.Sprintf("rest/api/1.0/repos?size=1000&permission=REPO_WRITE&projectname=%s&name=%s", namespace, name)
+	path := fmt.Sprintf("rest/api/1.0/repos?size=1000&permission=REPO_WRITE&project=%s&name=%s", namespace, name)
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	return convertRepositoryList(out), res, err

--- a/scm/driver/stash/repo_test.go
+++ b/scm/driver/stash/repo_test.go
@@ -157,7 +157,7 @@ func TestRepositoryPerms_Write(t *testing.T) {
 		Get("/rest/api/1.0/repos").
 		MatchParam("size", "1000").
 		MatchParam("permission", "REPO_WRITE").
-		MatchParam("projectname", "PRJ").
+		MatchParam("project", "PRJ").
 		MatchParam("name", "my-repo").
 		Reply(200).
 		Type("application/json").


### PR DESCRIPTION
tested with bitbucket server 7.6.0

https://discourse.drone.io/t/bitbucket-credentials-not-properly-fetched-after-upgrade/9246/4

fix #87 