### PR TITLE
[proposal/gitea driver] cosider all repo in private organization as private

### DIFF
--- a/scm/driver/gitea/repo.go
+++ b/scm/driver/gitea/repo.go
@@ -211,7 +211,7 @@ func convertRepository(src *repository) *scm.Repository {
 		Name:      src.Name,
 		Perm:      convertPerm(src.Permissions),
 		Branch:    src.DefaultBranch,
-		Private:   src.Private,
+		Private:   src.Private || src.Owner.Visibility != "public",
 		Clone:     src.CloneURL,
 		CloneSSH:  src.SSHURL,
 		Link:      src.HTMLURL,

--- a/scm/driver/gitea/user.go
+++ b/scm/driver/gitea/user.go
@@ -44,6 +44,8 @@ type user struct {
 	Fullname string `json:"full_name"`
 	Email    string `json:"email"`
 	Avatar   string `json:"avatar_url"`
+	// User visibility level option: public, limited, private
+	Visibility string `json:"visibility"`
 }
 
 //


### PR DESCRIPTION
Hello, I found only when the repo is private or
set `DRONE_GIT_ALWAYS_AUTH`, drone will
use authenticate. but for a public repo
in private org, authenticate is also
necessary. so I think it's necessary
to cosider all repo in private organization
as private, thanks.
