### PR TITLE
Update GitHub signature header to use sha256

### DIFF
--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -64,6 +64,9 @@ func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhoo
 	}
 
 	sig := req.Header.Get("X-Hub-Signature-256")
+	if sig == "" {
+		sig = req.Header.Get("X-Hub-Signature")
+	}
 	if !hmac.ValidatePrefix(data, []byte(key), sig) {
 		return hook, scm.ErrSignatureInvalid
 	}

--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -63,7 +63,7 @@ func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhoo
 		return hook, nil
 	}
 
-	sig := req.Header.Get("X-Hub-Signature")
+	sig := req.Header.Get("X-Hub-Signature-256")
 	if !hmac.ValidatePrefix(data, []byte(key), sig) {
 		return hook, scm.ErrSignatureInvalid
 	}

--- a/scm/driver/github/webhook_test.go
+++ b/scm/driver/github/webhook_test.go
@@ -202,7 +202,7 @@ func TestWebhooks(t *testing.T) {
 		buf := bytes.NewBuffer(before)
 		r, _ := http.NewRequest("GET", "/", buf)
 		r.Header.Set("X-GitHub-Event", test.event)
-		r.Header.Set("X-Hub-Signature", "sha1=380f462cd2e160b84765144beabdad2e930a7ec5")
+		r.Header.Set("X-Hub-Signature-256", "sha256=3bfbbc3bfc44498db2254f577b2e4bed201ece6163518ba91cb2c21f0f59d512")
 		r.Header.Set("X-GitHub-Delivery", "f2467dea-70d6-11e8-8955-3c83993e0aef")
 
 		s := new(webhookService)
@@ -259,7 +259,7 @@ func TestWebhookInvalid(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/", bytes.NewBuffer(f))
 	r.Header.Set("X-GitHub-Event", "push")
 	r.Header.Set("X-GitHub-Delivery", "ee8d97b4-1479-43f1-9cac-fbbd1b80da55")
-	r.Header.Set("X-Hub-Signature", "sha1=380f462cd2e160b84765144beabdad2e930a7ec5")
+	r.Header.Set("X-Hub-Signature-256", "sha256=3bfbbc3bfc44498db2254f577b2e4bed201ece6163518ba91cb2c21f0f59d512")
 
 	s := new(webhookService)
 	_, err := s.Parse(r, secretFunc)
@@ -270,13 +270,13 @@ func TestWebhookInvalid(t *testing.T) {
 
 func TestWebhookValid(t *testing.T) {
 	// the sha can be recalculated with the below command
-	// openssl dgst -sha1 -hmac <secret> <file>
+	// openssl dgst -sha256 -hmac <secret> <file>
 
 	f, _ := ioutil.ReadFile("testdata/webhooks/push.json")
 	r, _ := http.NewRequest("GET", "/", bytes.NewBuffer(f))
 	r.Header.Set("X-GitHub-Event", "push")
 	r.Header.Set("X-GitHub-Delivery", "ee8d97b4-1479-43f1-9cac-fbbd1b80da55")
-	r.Header.Set("X-Hub-Signature", "sha1=cf93f9ba3c8d3a789e61f91e1e5c6a360d036e98")
+	r.Header.Set("X-Hub-Signature-256", "sha256=e3bfe744d4e2e29ed990bde8acfb8255ca51ef65f99657767989fb6349f32957")
 
 	s := new(webhookService)
 	_, err := s.Parse(r, secretFunc)

--- a/scm/driver/github/webhook_test.go
+++ b/scm/driver/github/webhook_test.go
@@ -285,6 +285,23 @@ func TestWebhookValid(t *testing.T) {
 	}
 }
 
+func TestWebhookSignatureFallback(t *testing.T) {
+	// the sha can be recalculated with the below command
+	// openssl dgst -sha1 -hmac <secret> <file>
+
+	f, _ := ioutil.ReadFile("testdata/webhooks/push.json")
+	r, _ := http.NewRequest("GET", "/", bytes.NewBuffer(f))
+	r.Header.Set("X-GitHub-Event", "push")
+	r.Header.Set("X-GitHub-Delivery", "ee8d97b4-1479-43f1-9cac-fbbd1b80da55")
+	r.Header.Set("X-Hub-Signature", "sha1=cf93f9ba3c8d3a789e61f91e1e5c6a360d036e98")
+
+	s := new(webhookService)
+	_, err := s.Parse(r, secretFunc)
+	if err != nil {
+		t.Errorf("Expect valid signature, got %v", err)
+	}
+}
+
 func secretFunc(scm.Webhook) (string, error) {
 	return "topsecret", nil
 }


### PR DESCRIPTION
Hi !

First of all, thanks for the work done on Drone.

Just a quick PR to update the header used to validate webhooks from GitHub.
https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github

GitHub still supports `X-Hub-Signature` for backward-compatibility but recommend using the `X-Hub-Signature-256`