### PR TITLE
Added support for parsing prevFilePath field from github compare commits API response

### DIFF
--- a/scm/driver/github/pr.go
+++ b/scm/driver/github/pr.go
@@ -118,12 +118,13 @@ type prInput struct {
 }
 
 type file struct {
-	BlobID    string `json:"sha"`
-	Filename  string `json:"filename"`
-	Status    string `json:"status"`
-	Additions int    `json:"additions"`
-	Deletions int    `json:"deletions"`
-	Changes   int    `json:"changes"`
+	BlobID           string `json:"sha"`
+	Filename         string `json:"filename"`
+	Status           string `json:"status"`
+	Additions        int    `json:"additions"`
+	Deletions        int    `json:"deletions"`
+	Changes          int    `json:"changes"`
+	PreviousFilename string `json:"previous_filename"`
 }
 
 func convertPullRequestList(from []*pr) []*scm.PullRequest {
@@ -185,10 +186,11 @@ func convertChangeList(from []*file) []*scm.Change {
 
 func convertChange(from *file) *scm.Change {
 	return &scm.Change{
-		Path:    from.Filename,
-		Added:   from.Status == "added",
-		Deleted: from.Status == "removed",
-		Renamed: from.Status == "renamed",
-		BlobID:  from.BlobID,
+		Path:         from.Filename,
+		Added:        from.Status == "added",
+		Deleted:      from.Status == "removed",
+		Renamed:      from.Status == "renamed",
+		BlobID:       from.BlobID,
+		PrevFilePath: from.PreviousFilename,
 	}
 }

--- a/scm/driver/github/testdata/pr_files.json.golden
+++ b/scm/driver/github/testdata/pr_files.json.golden
@@ -4,27 +4,31 @@
         "Added": false,
         "Renamed": false,
         "Deleted": false,
-        "BlobID": "291b15982c4926705f5639abffe96b2b6c419ce7"
+        "BlobID": "291b15982c4926705f5639abffe96b2b6c419ce7",
+        "PrevFilePath": ""
     },
     {
         "Path": "remove_me",
         "Added": true,
         "Renamed": false,
         "Deleted": false,
-        "BlobID": "ce013625030ba8dba906f756967f9e9ca394464a"
+        "BlobID": "ce013625030ba8dba906f756967f9e9ca394464a",
+        "PrevFilePath": ""
     },
     {
         "Path": "tp",
         "Added": false,
         "Renamed": true,
         "Deleted": false,
-        "BlobID": "70c379b63ffa0795fdbfbc128e5a2818397b7ef8"
+        "BlobID": "70c379b63ffa0795fdbfbc128e5a2818397b7ef8",
+        "PrevFilePath": "abhinav"
     },
     {
         "Path": "upsert",
         "Added": false,
         "Renamed": false,
         "Deleted": true,
-        "BlobID": "0f9282d7e71e0f8cb748bfe00e52d7ed13dad036"
+        "BlobID": "0f9282d7e71e0f8cb748bfe00e52d7ed13dad036",
+        "PrevFilePath": ""
     }
 ]

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -51,12 +51,13 @@ type (
 
 	// Change represents a changed file.
 	Change struct {
-		Path    string
-		Added   bool
-		Renamed bool
-		Deleted bool
-		Sha     string
-		BlobID  string
+		Path         string
+		Added        bool
+		Renamed      bool
+		Deleted      bool
+		Sha          string
+		BlobID       string
+		PrevFilePath string
 	}
 
 	Label struct {


### PR DESCRIPTION
In case of RENAME ops, it returns prevFilePath of the file that has been renamed. So, added support to parse that field as part of go-scm API response.