### PR TITLE
Bitbucket list files fix

### DIFF
--- a/scm/driver/bitbucket/content.go
+++ b/scm/driver/bitbucket/content.go
@@ -83,6 +83,10 @@ func (s *contentService) Delete(ctx context.Context, repo, path string, params *
 
 func (s *contentService) List(ctx context.Context, repo, path, ref string, opts scm.ListOptions) ([]*scm.ContentInfo, *scm.Response, error) {
 	endpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s?%s", repo, ref, path, encodeListOptions(opts))
+	if opts.URL != "" {
+		endpoint = opts.URL
+	}
+
 	out := new(contents)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	copyPagination(out.pagination, res)

--- a/scm/driver/bitbucket/content_test.go
+++ b/scm/driver/bitbucket/content_test.go
@@ -240,3 +240,29 @@ func TestContentList(t *testing.T) {
 		t.Log(diff)
 	}
 }
+
+func TestContentListWithUrlInput(t *testing.T) {
+	defer gock.Off()
+
+	mockNextPageUri := "https://api.bitbucket.org/2.0/repositories/atlassian/atlaskit/src/master/packages/activity?pageLen=3&page=RPfL"
+
+	gock.New(mockNextPageUri).
+		Reply(200).
+		Type("application/json").
+		File("testdata/content_list.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	got, _, err := client.Contents.List(context.Background(), "atlassian/atlaskit", "packages/activity", "master", scm.ListOptions{URL: mockNextPageUri})
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := []*scm.ContentInfo{}
+	raw, _ := ioutil.ReadFile("testdata/content_list.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}


### PR DESCRIPTION
Currently, we only return first page of list files for bitbucket. It doesn't respect the incoming page number argument.

Bitbucket works on URL based pagination. Thus, added support if incoming page request has url, then it should be used, otherwise first page response will be returned.