### PR TITLE
Remove the null value de-reference issue when the bitbucket server url is nil

### DIFF
--- a/scm/driver/stash/integration/repo_test.go
+++ b/scm/driver/stash/integration/repo_test.go
@@ -1,0 +1,37 @@
+package integration
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/drone/go-scm/scm/driver/stash"
+	"github.com/drone/go-scm/scm/transport"
+)
+
+func TestListRepos(t *testing.T) {
+	if token == "" {
+		t.Skip("Skipping, Acceptance test")
+	}
+	client, _ = stash.New(endpoint)
+	client.Client = &http.Client{
+		Transport: &transport.BasicAuth{
+			Username: username,
+			Password: token,
+		},
+	}
+
+	repos, response, listerr := client.Repositories.List(context.Background(), scm.ListOptions{})
+	if listerr != nil {
+		t.Errorf("List Repos got an error %v", listerr)
+	}
+	if response.Status != http.StatusOK {
+		t.Errorf("List Repos did not get a 200 back %v", response.Status)
+	}
+
+	if len(repos) == 0 {
+		t.Errorf("Got Empty repo list")
+	}
+
+}

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -161,7 +161,7 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 	path := fmt.Sprintf("rest/api/1.0/repos?%s", encodeListRoleOptions(opts))
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if res != nil && !out.pagination.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -183,7 +183,7 @@ func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts scm
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/webhooks?%s", namespace, name, encodeListOptions(opts))
 	out := new(hooks)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if res != nil && !out.pagination.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}


### PR DESCRIPTION
If the endpoint is wrong, then we won't be able to reach the server and we will get a nil response. I have added a check for this nil response in this PR