### PR TITLE
remove redundant slash from list commits api

### DIFF
--- a/scm/driver/github/pr.go
+++ b/scm/driver/github/pr.go
@@ -39,7 +39,7 @@ func (s *pullService) ListChanges(ctx context.Context, repo string, number int, 
 }
 
 func (s *pullService) ListCommits(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Commit, *scm.Response, error) {
-	path := fmt.Sprintf("/repos/%s/pulls/%d/commits?%s", repo, number, encodeListOptions(opts))
+	path := fmt.Sprintf("repos/%s/pulls/%d/commits?%s", repo, number, encodeListOptions(opts))
 	out := []*commit{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertCommitList(out), res, err


### PR DESCRIPTION
This is causing a CFD: [CI-4478](https://harness.atlassian.net/browse/CI-4478) and because of this calls to onprem github fail for listing commits with error: 
```
2022-06-02 00:10:58,536 [task-exec-6] WARN  io.harness.utils.ScmGrpcClientUtils - Scm grpc retry attempt: 1 [accountId=kmpySmUISimoRrJL6NL73w, taskId=q0-Yv7CAQZmm783fvY_Ybg] 
io.grpc.StatusRuntimeException: UNKNOWN: invalid character '<' looking for beginning of value
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:262)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:243)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:156)
	at io.harness.product.ci.scm.proto.SCMGrpc$SCMBlockingStub.listCommitsInPR(SCMGrpc.java:1794)
	at io.harness.utils.ScmGrpcClientUtils.lambda$retryAndProcessException$0(ScmGrpcClientUtils.java:35)
	at net.jodah.failsafe.Functions.lambda$resultSupplierOf$11(Functions.java:284)
	at net.jodah.failsafe.RetryPolicyExecutor.lambda$supply$0(RetryPolicyExecutor.java:63)
	at net.jodah.failsafe.Execution.executeSync(Execution.java:129)
	at net.jodah.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:379)
```