### PR TITLE
[PL-25889]: fix list branches Azure API

### DIFF
--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -19,8 +19,8 @@ type gitService struct {
 func (s *gitService) CreateBranch(ctx context.Context, repo string, params *scm.CreateBranch) (*scm.Response, error) {
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/refs/update-refs?view=azure-devops-rest-6.0
 	if s.client.project == "" {
-    	return nil, ProjectRequiredError()
-    }
+		return nil, ProjectRequiredError()
+	}
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?api-version=6.0", s.client.owner, s.client.project, repo)
 
 	in := make(crudBranch, 1)
@@ -32,16 +32,16 @@ func (s *gitService) CreateBranch(ctx context.Context, repo string, params *scm.
 
 func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Reference, *scm.Response, error) {
 	if s.client.project == "" {
-    	return nil, nil, ProjectRequiredError()
-    }
+		return nil, nil, ProjectRequiredError()
+	}
 	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/commits/get?view=azure-devops-rest-6.0#get-by-id
 	if s.client.project == "" {
-    	return nil, nil, ProjectRequiredError()
-    }
+		return nil, nil, ProjectRequiredError()
+	}
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/commits/%s?api-version=6.0", s.client.owner, s.client.project, repo, ref)
 	out := new(gitCommit)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
@@ -55,9 +55,9 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/refs/list?view=azure-devops-rest-6.0
 	if s.client.project == "" {
-    	return nil, nil, ProjectRequiredError()
-    }
-	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?api-version=6.0", s.client.owner, s.client.project, repo)
+		return nil, nil, ProjectRequiredError()
+	}
+	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?includeMyBranches=true&api-version=6.0", s.client.owner, s.client.project, repo)
 	out := new(branchList)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
 	return convertBranchList(out.Value), res, err
@@ -66,8 +66,8 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOp
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-commits?view=azure-devops-rest-6.0
 	if s.client.project == "" {
-    	return nil, nil, ProjectRequiredError()
-    }
+		return nil, nil, ProjectRequiredError()
+	}
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/commits?", s.client.owner, s.client.project, repo)
 	if opts.Ref != "" {
 		endpoint += fmt.Sprintf("searchCriteria.itemVersion.version=%s&", opts.Ref)
@@ -93,8 +93,8 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.Li
 func (s *gitService) CompareChanges(ctx context.Context, repo, source, target string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/diffs/get?view=azure-devops-rest-6.0
 	if s.client.project == "" {
-    	return nil, nil, ProjectRequiredError()
-    }
+		return nil, nil, ProjectRequiredError()
+	}
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/diffs/commits?", s.client.owner, s.client.project, repo)
 	// add base
 	endpoint += fmt.Sprintf("baseVersion=%s&baseVersionType=commit&", source)


### PR DESCRIPTION
for list branches api in azure, we use, list refs API of Azure which lists all the branches along with pull requests, that's why for listing only branches, an optional parameter is added, `includeMyBranches`