### PR TITLE
Fix Gogs find commit

### DIFF
--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -29,8 +29,10 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	if scm.IsHash(ref) == false {
-		if branch, _, err := s.FindBranch(ctx, repo, scm.TrimRef(ref)); err == nil {
-			ref = branch.Sha // replace ref with sha
+		path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)
+		res, err := s.client.do(ctx, "GET", path, nil, ref)
+		if err != nil {
+			return nil, res, err
 		}
 	}
 	path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -7,6 +7,7 @@ package gogs
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -30,10 +31,12 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	if scm.IsHash(ref) == false {
 		path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)
-		res, err := s.client.do(ctx, "GET", path, nil, &ref)
+		buf := new(strings.Builder)
+		res, err := s.client.do(ctx, "GET", path, buf, nil)
 		if err != nil {
 			return nil, res, err
 		}
+		ref = buf.String()
 	}
 	path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)
 	out := new(commitDetail)

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -30,6 +30,14 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)
 	out := new(commitDetail)
+	if ! ref.matches("^[a-fA-F0-9]{40}$") {
+		res, err := s.client.do(ctx, "GET", path, nil)
+		if err != nil {
+			log.Fatal(err) // exception?
+		}
+		sha := string(res.Body)
+		path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, sha)
+	}
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	return convertCommit(out), res, err
 }

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -28,16 +28,13 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 }
 
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
+	if scm.IsHash(ref) == false {
+		if branch, _, err := s.FindBranch(ctx, repo, scm.TrimRef(ref)); err == nil {
+			ref = branch.Sha // replace ref with sha
+		}
+	}
 	path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)
 	out := new(commitDetail)
-	if ! ref.matches("^[a-fA-F0-9]{40}$") {
-		res, err := s.client.do(ctx, "GET", path, nil)
-		if err != nil {
-			log.Fatal(err) // exception?
-		}
-		sha := string(res.Body)
-		path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, sha)
-	}
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	return convertCommit(out), res, err
 }

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -30,7 +30,7 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	if scm.IsHash(ref) == false {
 		path := fmt.Sprintf("api/v1/repos/%s/commits/%s", repo, ref)
-		res, err := s.client.do(ctx, "GET", path, nil, ref)
+		res, err := s.client.do(ctx, "GET", path, nil, &ref)
 		if err != nil {
 			return nil, res, err
 		}

--- a/scm/driver/gogs/git_test.go
+++ b/scm/driver/gogs/git_test.go
@@ -62,7 +62,7 @@ func TestCommitFindByRefs(t *testing.T) {
 	got, _, err := client.Git.FindCommit(
 		context.Background(),
 		"gogs/gogs",
-		"refs/heads/master"
+		"refs/heads/master",
 	)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This PR fixes `findCommit` from Gogs when reference is not a SHA1.