### PR TITLE
added omitempty annotation for secret

### DIFF
--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -81,7 +81,7 @@ type hookInput struct {
 	URL    string   `json:"url"`
 	Active bool     `json:"active"`
 	Config struct {
-		Secret string `json:"secret"`
+		Secret string `json:"secret,omitempty"`
 	} `json:"configuration"`
 }
 


### PR DESCRIPTION
For bitbucket on-prem, if the secret value is empty then it gives a 5xx. This behaviour was seen with bitbucket 7.1.2. Adding omitempty tag for secret field.