### PR TITLE
Add Actor UUID to Sender for all webhooks responses for Bitbucket

### DIFF
--- a/scm/driver/bitbucket/testdata/webhooks/pr_created.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_created.json.golden
@@ -35,6 +35,7 @@
         "Updated": "2018-07-02T21:51:39.532546Z"
     },
     "Sender": {
+        "ID": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}",
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",
         "Email": "",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_declined.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_declined.json.golden
@@ -35,6 +35,7 @@
         "Updated": "2018-07-03T01:44:00.030575Z"
     },
     "Sender": {
+        "ID": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}",
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",
         "Email": "",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_fulfilled.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_fulfilled.json.golden
@@ -36,6 +36,7 @@
         "Updated": "2018-07-03T01:28:05.903251Z"
     },
     "Sender": {
+        "ID": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}",
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",
         "Email": "",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_updated.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_updated.json.golden
@@ -35,6 +35,7 @@
         "Updated": "2018-07-02T21:54:34.210775Z"
     },
     "Sender": {
+        "ID": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}",
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",
         "Email": "",

--- a/scm/driver/bitbucket/testdata/webhooks/push_branch_delete.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_branch_delete.json.golden
@@ -18,6 +18,7 @@
     },
     "Action": "deleted",
     "Sender": {
+        "ID": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}",
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",
         "Email": "",

--- a/scm/driver/bitbucket/testdata/webhooks/push_tag_delete.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_tag_delete.json.golden
@@ -18,6 +18,7 @@
     },
     "Action": "deleted",
     "Sender": {
+        "ID": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}",
         "Login": "brydzewski",
         "Name": "Brad Rydzewski",
         "Email": "",

--- a/scm/driver/bitbucket/webhook.go
+++ b/scm/driver/bitbucket/webhook.go
@@ -716,6 +716,7 @@ func convertBranchDeleteHook(src *pushHook) *scm.BranchHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
+			ID:     src.Actor.UUID,
 			Login:  src.Actor.Username,
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
@@ -743,6 +744,7 @@ func convertTagCreateHook(src *pushHook) *scm.TagHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
+			ID:     src.Actor.UUID,
 			Login:  src.Actor.Username,
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
@@ -770,6 +772,7 @@ func convertTagDeleteHook(src *pushHook) *scm.TagHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
+			ID:     src.Actor.UUID,
 			Login:  src.Actor.Username,
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
@@ -816,6 +819,7 @@ func convertPullRequestHook(src *webhook) *scm.PullRequestHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
+			ID:     src.Actor.UUID,
 			Login:  src.Actor.Username,
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,


### PR DESCRIPTION
Earlier we added the Actor UUID in Sender for PR Comment webhook event for Bitbucket. We're extending this info in the other webhooks events as well. This is required for Harness licensing.