### PR TITLE
feat: [PIE-7927]: added header to avoid/bypass csrf check

### DIFF
--- a/scm/driver/stash/stash.go
+++ b/scm/driver/stash/stash.go
@@ -69,7 +69,8 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 		Method: method,
 		Path:   path,
 		Header: map[string][]string{
-			"Accept": {"application/json"},
+			"Accept":            {"application/json"},
+			"x-atlassian-token": {"no-token"},
 		},
 	}
 	// if we are posting or putting data, we need to


### PR DESCRIPTION
We got a customer issue that they are getting CSRF check issues while using bitbucket on-prem connector. They suggested to add a HTTP header to requests to bypass this issue. We read more on it and found it safe to add such a header. Adding "x-atlassian-token" header helps to bypass csrf checks which are of no significance while using APIs.

For more details, refer: https://community.sonarsource.com/t/bitbucket-server-integration-csrf-xsrf-warning-in-logs/23604/4