### PR TITLE
[feat]: [CDS-73030]: Support for text based branch filtration    

### DIFF
--- a/scm/client.go
+++ b/scm/client.go
@@ -68,6 +68,13 @@ type (
 		Reset     int64
 	}
 
+	// BranchListOptions specifies optional branch search term and pagination
+	// parameters.
+	BranchListOptions struct {
+		SearchTerm      string
+		PageListOptions ListOptions
+	}
+
 	// ListOptions specifies optional pagination
 	// parameters.
 	ListOptions struct {

--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"time"
-
+	
 	"github.com/drone/go-scm/scm"
 )
 
@@ -58,6 +58,18 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOp
 		return nil, nil, ProjectRequiredError()
 	}
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?includeMyBranches=true&api-version=6.0", s.client.owner, s.client.project, repo)
+	out := new(branchList)
+	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
+	return convertBranchList(out.Value), res, err
+}
+
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, _ scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/refs/list?view=azure-devops-rest-6.0
+	if s.client.project == "" {
+		return nil, nil, ProjectRequiredError()
+	}
+	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?api-version=6.0&filterContains=%s", s.client.owner, s.client.project, repo, branch)
+	
 	out := new(branchList)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
 	return convertBranchList(out.Value), res, err

--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -6,7 +6,6 @@ package azure
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -64,15 +63,9 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Bra
 	} else {
 		endpoint = fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?includeMyBranches=true&api-version=6.0", s.client.owner, s.client.project, repo)
 	}
-	dump(endpoint)
 	out := new(branchList)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
 	return convertBranchList(out.Value), res, err
-}
-
-func dump(data interface{}) {
-	b, _ := json.MarshalIndent(data, "", "  ")
-	fmt.Print(string(b))
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"time"
-	
+
 	"github.com/drone/go-scm/scm"
 )
 
@@ -69,7 +69,6 @@ func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo stri
 		return nil, nil, ProjectRequiredError()
 	}
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?api-version=6.0&filterContains=%s", s.client.owner, s.client.project, repo, branch)
-	
 	out := new(branchList)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
 	return convertBranchList(out.Value), res, err

--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -6,6 +6,7 @@ package azure
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -63,9 +64,15 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Bra
 	} else {
 		endpoint = fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?includeMyBranches=true&api-version=6.0", s.client.owner, s.client.project, repo)
 	}
+	dump(endpoint)
 	out := new(branchList)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
 	return convertBranchList(out.Value), res, err
+}
+
+func dump(data interface{}) {
+	b, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Print(string(b))
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/azure/git_test.go
+++ b/scm/driver/azure/git_test.go
@@ -123,6 +123,32 @@ func TestGitListBranches(t *testing.T) {
 	}
 }
 
+func TestGitListBranchesWithBranchFilter(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https:/dev.azure.com/").
+		Get("/ORG/PROJ/_apis/git/repositories/REPOID/").
+		Reply(200).
+		Type("application/json").
+		File("testdata/branchesFilter.json")
+
+	client := NewDefault("ORG", "PROJ")
+	got, _, err := client.Git.ListBranchesWithBranchFilter(context.Background(), "REPOID", "main", scm.ListOptions{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := []*scm.Reference{}
+	raw, _ := ioutil.ReadFile("testdata/branchesFilter.json.golden")
+	_ = json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
 func TestGitCompareChanges(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/azure/testdata/branchesFilter.json
+++ b/scm/driver/azure/testdata/branchesFilter.json
@@ -1,0 +1,41 @@
+{
+  "value": [
+    {
+      "name": "refs/heads/main",
+      "objectId": "e0aee6aa543294d62520fb906689da6710af149c",
+      "creator": {
+        "displayName": "tp",
+        "url": "https://spsproduks1.vssps.visualstudio.com/A93f74f38-2b8d-42d4-a5cb-74646f46666e/_apis/Identities/3ff4a20f-306e-677e-8a01-57f35e71f109",
+        "_links": {
+          "avatar": {
+            "href": "https://dev.azure.com/tphoney/_apis/GraphProfile/MemberAvatars/msa.M2ZmNGEyMGYtMzA2ZS03NzdlLThhMDEtNTdmMzVlNzFmMTA5"
+          }
+        },
+        "id": "3ff4a20f-306e-677e-8a01-57f35e71f109",
+        "uniqueName": "tp@harness.io",
+        "imageUrl": "https://dev.azure.com/tphoney/_api/_common/identityImage?id=3ff4a20f-306e-677e-8a01-57f35e71f109",
+        "descriptor": "msa.M2ZmNGEyMGYtMzA2ZS03NzdlLThhMDEtNTdmMzVlNzFmMTA5"
+      },
+      "url": "https://dev.azure.com/tphoney/d350c9c0-7749-4ff8-a78f-f9c1f0e56729/_apis/git/repositories/fde2d21f-13b9-4864-a995-83329045289a/refs?filter=heads%2Fmain"
+    },
+    {
+      "name": "refs/heads/main-patch",
+      "objectId": "01768d964c03e97260af0bd8cd9e5cd1f9ac6356",
+      "creator": {
+        "displayName": "tp",
+        "url": "https://spsproduks1.vssps.visualstudio.com/A93f74f38-2b8d-42d4-a5cb-74646f46666e/_apis/Identities/3ff4a20f-306e-677e-8a01-57f35e71f109",
+        "_links": {
+          "avatar": {
+            "href": "https://dev.azure.com/tphoney/_apis/GraphProfile/MemberAvatars/msa.M2ZmNGEyMGYtMzA2ZS03NzdlLThhMDEtNTdmMzVlNzFmMTA5"
+          }
+        },
+        "id": "3ff4a20f-306e-677e-8a01-57f35e71f109",
+        "uniqueName": "tp@harness.io",
+        "imageUrl": "https://dev.azure.com/tphoney/_api/_common/identityImage?id=3ff4a20f-306e-677e-8a01-57f35e71f109",
+        "descriptor": "msa.M2ZmNGEyMGYtMzA2ZS03NzdlLThhMDEtNTdmMzVlNzFmMTA5"
+      },
+      "url": "https://dev.azure.com/tphoney/d350c9c0-7749-4ff8-a78f-f9c1f0e56729/_apis/git/repositories/fde2d21f-13b9-4864-a995-83329045289a/refs?filter=heads%2Fpr_branch"
+    }
+  ],
+  "count": 2
+}

--- a/scm/driver/azure/testdata/branchesFilter.json.golden
+++ b/scm/driver/azure/testdata/branchesFilter.json.golden
@@ -1,0 +1,12 @@
+[
+  {
+    "Name": "main",
+    "Path": "refs/heads/main",
+    "Sha": "e0aee6aa543294d62520fb906689da6710af149c"
+  },
+  {
+    "Name": "main-patch",
+    "Path": "refs/heads/main-patch",
+    "Sha": "01768d964c03e97260af0bd8cd9e5cd1f9ac6356"
+  }
+]

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -60,6 +60,7 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("2.0/repositories/%s/refs/branches?%s", repo, encodeBranchListOptions(opts))
+	dump(encodeBranchListOptions(opts))
 	dump(path)
 	//path := fmt.Sprintf("2.0/repositories/%s/refs/branches?q~name=\"%s\"&%s", repo, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
 	out := new(branches)

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -57,16 +57,8 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return convertTag(out), res, err
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories/%s/refs/branches?%s", repo, encodeListOptions(opts))
-	out := new(branches)
-	res, err := s.client.do(ctx, "GET", path, nil, out)
-	copyPagination(out.pagination, res)
-	return convertBranchList(out), res, err
-}
-
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories/%s/refs?q~name=\"%s\"&%s", repo, branch, encodeListOptions(opts))
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("2.0/repositories/%s/refs/branches?q~name=\"%s\"&%s", repo, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -6,7 +6,6 @@ package bitbucket
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -60,18 +59,10 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("2.0/repositories/%s/refs/branches?%s", repo, encodeBranchListOptions(opts))
-	dump(encodeBranchListOptions(opts))
-	dump(path)
-	//path := fmt.Sprintf("2.0/repositories/%s/refs/branches?q~name=\"%s\"&%s", repo, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)
 	return convertBranchList(out), res, err
-}
-
-func dump(data interface{}) {
-	b, _ := json.MarshalIndent(data, "", "  ")
-	fmt.Print(string(b))
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -6,6 +6,7 @@ package bitbucket
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -58,11 +59,18 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 }
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories/%s/refs/branches?q~name=\"%s\"&%s", repo, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
+	path := fmt.Sprintf("2.0/repositories/%s/refs/branches?%s", repo, encodeBranchListOptions(opts))
+	dump(path)
+	//path := fmt.Sprintf("2.0/repositories/%s/refs/branches?q~name=\"%s\"&%s", repo, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)
 	return convertBranchList(out), res, err
+}
+
+func dump(data interface{}) {
+	b, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Print(string(b))
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -65,6 +65,14 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Lis
 	return convertBranchList(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("2.0/repositories/%s/refs?q~name=\"%s\"&%s", repo, branch, encodeListOptions(opts))
+	out := new(branches)
+	res, err := s.client.do(ctx, "GET", path, nil, out)
+	copyPagination(out.pagination, res)
+	return convertBranchList(out), res, err
+}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("2.0/repositories/%s/commits/%s?%s", repo, opts.Ref, encodeCommitListOptions(opts))
 	out := new(commits)

--- a/scm/driver/bitbucket/git_test.go
+++ b/scm/driver/bitbucket/git_test.go
@@ -206,6 +206,36 @@ func TestGitListBranches(t *testing.T) {
 	t.Run("Page", testPage(res))
 }
 
+func TestGitListBranchesWithBranchFilter(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian/stash-example-plugin/refs").
+		MatchParam("q~name", "\\\"mast\\\"").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "30").
+		Reply(200).
+		Type("application/json").
+		File("testdata/branchesFilter.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	got, res, err := client.Git.ListBranchesWithBranchFilter(context.Background(), "atlassian/stash-example-plugin", "mast", scm.ListOptions{Page: 1, Size: 30})
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := []*scm.Reference{}
+	raw, _ := ioutil.ReadFile("testdata/branchesFilter.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	t.Run("Page", testPage(res))
+}
+
 func TestGitListTags(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/bitbucket/testdata/branchesFilter.json
+++ b/scm/driver/bitbucket/testdata/branchesFilter.json
@@ -1,0 +1,201 @@
+{
+  "pagelen": 30,
+  "values": [
+    {
+      "type": "branch",
+      "name": "master",
+      "links": {
+        "commits": {
+          "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commits\/master"
+        },
+        "self": {
+          "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/refs\/branches\/master"
+        },
+        "html": {
+          "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/branch\/master"
+        }
+      },
+      "target": {
+        "hash": "a6e5e7d797edf751cbd839d6bd4aef86c941eec9",
+        "repository": {
+          "links": {
+            "self": {
+              "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin"
+            },
+            "html": {
+              "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin"
+            },
+            "avatar": {
+              "href": "https:\/\/bytebucket.org\/ravatar\/%7B7dd600e6-0d9c-4801-b967-cb4cc17359ff%7D?ts=default"
+            }
+          },
+          "type": "repository",
+          "name": "stash-example-plugin",
+          "full_name": "atlassian\/stash-example-plugin",
+          "uuid": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}"
+        },
+        "links": {
+          "self": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "comments": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9\/comments"
+          },
+          "patch": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/patch\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "html": {
+            "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/commits\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "diff": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/diff\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "approve": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9\/approve"
+          },
+          "statuses": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9\/statuses"
+          }
+        },
+        "author": {
+          "raw": "Adam Ahmed <aahmed@atlassian.com>",
+          "type": "author",
+          "user": {
+            "username": "aahmed",
+            "display_name": "Adam Ahmed",
+            "account_id": "557057:74dc5efb-ffe7-49af-b427-6abc299bb3b9",
+            "links": {
+              "self": {
+                "href": "https:\/\/api.bitbucket.org\/2.0\/users\/aahmed"
+              },
+              "html": {
+                "href": "https:\/\/bitbucket.org\/aahmed\/"
+              },
+              "avatar": {
+                "href": "https:\/\/bitbucket.org\/account\/aahmed\/avatar\/32\/"
+              }
+            },
+            "type": "user",
+            "uuid": "{3d5de233-98d4-4138-b4af-8678fbb009ad}"
+          }
+        },
+        "parents": [
+          {
+            "hash": "5be6855032e171280a1acb860d7265c29f40487c",
+            "type": "commit",
+            "links": {
+              "self": {
+                "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/5be6855032e171280a1acb860d7265c29f40487c"
+              },
+              "html": {
+                "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/commits\/5be6855032e171280a1acb860d7265c29f40487c"
+              }
+            }
+          }
+        ],
+        "date": "2015-08-27T03:25:04+00:00",
+        "message": "Add Apache 2.0 License\n",
+        "type": "commit"
+      }
+    },
+    {
+      "type": "branch",
+      "name": "master-patch",
+      "links": {
+        "commits": {
+          "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commits\/master"
+        },
+        "self": {
+          "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/refs\/branches\/master"
+        },
+        "html": {
+          "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/branch\/master"
+        }
+      },
+      "target": {
+        "hash": "a6e5e7d797edf751cbd839d6bd4aef86c941eec8",
+        "repository": {
+          "links": {
+            "self": {
+              "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin"
+            },
+            "html": {
+              "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin"
+            },
+            "avatar": {
+              "href": "https:\/\/bytebucket.org\/ravatar\/%7B7dd600e6-0d9c-4801-b967-cb4cc17359ff%7D?ts=default"
+            }
+          },
+          "type": "repository",
+          "name": "stash-example-plugin",
+          "full_name": "atlassian\/stash-example-plugin",
+          "uuid": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}"
+        },
+        "links": {
+          "self": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "comments": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9\/comments"
+          },
+          "patch": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/patch\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "html": {
+            "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/commits\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "diff": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/diff\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+          },
+          "approve": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9\/approve"
+          },
+          "statuses": {
+            "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/a6e5e7d797edf751cbd839d6bd4aef86c941eec9\/statuses"
+          }
+        },
+        "author": {
+          "raw": "Adam Ahmed <aahmed@atlassian.com>",
+          "type": "author",
+          "user": {
+            "username": "aahmed",
+            "display_name": "Adam Ahmed",
+            "account_id": "557057:74dc5efb-ffe7-49af-b427-6abc299bb3b9",
+            "links": {
+              "self": {
+                "href": "https:\/\/api.bitbucket.org\/2.0\/users\/aahmed"
+              },
+              "html": {
+                "href": "https:\/\/bitbucket.org\/aahmed\/"
+              },
+              "avatar": {
+                "href": "https:\/\/bitbucket.org\/account\/aahmed\/avatar\/32\/"
+              }
+            },
+            "type": "user",
+            "uuid": "{3d5de233-98d4-4138-b4af-8678fbb009ad}"
+          }
+        },
+        "parents": [
+          {
+            "hash": "5be6855032e171280a1acb860d7265c29f40487c",
+            "type": "commit",
+            "links": {
+              "self": {
+                "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/atlassian\/stash-example-plugin\/commit\/5be6855032e171280a1acb860d7265c29f40487c"
+              },
+              "html": {
+                "href": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/commits\/5be6855032e171280a1acb860d7265c29f40487c"
+              }
+            }
+          }
+        ],
+        "date": "2015-08-27T03:25:04+00:00",
+        "message": "Add Apache 2.0 License\n",
+        "type": "commit"
+      }
+    }
+  ],
+  "page": 1,
+  "next": "https:\/\/bitbucket.org\/atlassian\/stash-example-plugin\/refs\/branches?pagelen=30&page=2"
+}

--- a/scm/driver/bitbucket/testdata/branchesFilter.json.golden
+++ b/scm/driver/bitbucket/testdata/branchesFilter.json.golden
@@ -1,0 +1,12 @@
+[
+    {
+        "Name": "master",
+        "Path": "refs/heads/master",
+        "Sha": "a6e5e7d797edf751cbd839d6bd4aef86c941eec9"
+    },
+    {
+        "Name": "master-patch",
+        "Path": "refs/heads/master-patch",
+        "Sha": "a6e5e7d797edf751cbd839d6bd4aef86c941eec8"
+    }
+]

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -24,6 +24,20 @@ func extractEmail(gitauthor string) (author string) {
 	return
 }
 
+func encodeBranchListOptions(opts scm.BranchListOptions) string {
+	params := url.Values{}
+	if opts.SearchTerm != "" {
+		params.Set("q~name=", opts.SearchTerm)
+	}
+	if opts.PageListOptions.Page != 0 {
+		params.Set("page", strconv.Itoa(opts.PageListOptions.Page))
+	}
+	if opts.PageListOptions.Size != 0 {
+		params.Set("pagelen", strconv.Itoa(opts.PageListOptions.Size))
+	}
+	return params.Encode()
+}
+
 func encodeListOptions(opts scm.ListOptions) string {
 	params := url.Values{}
 	if opts.Page != 0 {

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -31,7 +31,7 @@ func encodeBranchListOptions(opts scm.BranchListOptions) string {
 		var sb strings.Builder
 		sb.WriteString("name~\"")
 		sb.WriteString(opts.SearchTerm)
-		sb.WriteString("")
+		sb.WriteString("\"")
 		params.Set("q", sb.String())
 	}
 	if opts.PageListOptions.Page != 0 {

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -27,7 +28,11 @@ func extractEmail(gitauthor string) (author string) {
 func encodeBranchListOptions(opts scm.BranchListOptions) string {
 	params := url.Values{}
 	if opts.SearchTerm != "" {
-		params.Set("q~name=", opts.SearchTerm)
+		var sb strings.Builder
+		sb.WriteString("name~\"")
+		sb.WriteString(opts.SearchTerm)
+		sb.WriteString("")
+		params.Set("q", sb.String())
 	}
 	if opts.PageListOptions.Page != 0 {
 		params.Set("page", strconv.Itoa(opts.PageListOptions.Page))

--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -52,15 +52,11 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return nil, res, scm.ErrNotFound
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/branches?%s", repo, encodeListOptions(opts))
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("api/v1/repos/%s/branches?%s", repo, encodeListOptions(opts.PageListOptions))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err
-}
-
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	return s.ListBranches(ctx, repo, opts)
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, _ scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -59,6 +59,10 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Lis
 	return convertBranchList(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	return s.ListBranches(ctx, repo, opts)
+}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, _ scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("api/v1/repos/%s/commits", repo)
 	out := []*commitInfo{}

--- a/scm/driver/gitee/git.go
+++ b/scm/driver/gitee/git.go
@@ -60,6 +60,10 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOp
 	return convertBranchList(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	return s.ListBranches(ctx, repo, opts)
+}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/commits?%s", repo, encodeCommitListOptions(opts))
 	out := []*commit{}

--- a/scm/driver/gitee/git.go
+++ b/scm/driver/gitee/git.go
@@ -53,15 +53,11 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return nil, res, err
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/branches", repo)
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err
-}
-
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	return s.ListBranches(ctx, repo, opts)
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -46,15 +46,11 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return convertRef(out), res, err
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("repos/%s/branches?%s", repo, encodeListOptions(opts))
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("repos/%s/branches?%s", repo, encodeListOptions(opts.PageListOptions))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err
-}
-
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	return s.ListBranches(ctx, repo, opts)
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -53,6 +53,10 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Lis
 	return convertBranchList(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	return s.ListBranches(ctx, repo, opts)
+}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/commits?%s", repo, encodeCommitListOptions(opts))
 	out := []*commit{}

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -53,15 +53,8 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return convertTag(out), res, err
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?%s", encode(repo), encodeListOptions(opts))
-	out := []*branch{}
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	return convertBranchList(out), res, err
-}
-
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, inputBranch string,  opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?search=%s&%s", encode(repo), inputBranch, encodeListOptions(opts))
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?search=%s&%s", encode(repo), opts.SearchTerm, encodeListOptions(opts.PageListOptions))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -6,7 +6,6 @@ package gitlab
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -56,15 +55,11 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?search=%s&%s", encode(repo), opts.SearchTerm, encodeBranchListOptions(opts))
-	dump(path)
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err
 }
-func dump(data interface{}) {
-	b, _ := json.MarshalIndent(data, "", "  ")
-	fmt.Print(string(b))
-}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/repository/commits?%s", encode(repo), encodeCommitListOptions(opts))
 	out := []*commit{}

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -60,6 +60,13 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Lis
 	return convertBranchList(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, inputBranch string,  opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?search=%s&%s", encode(repo), inputBranch, encodeListOptions(opts))
+	out := []*branch{}
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	return convertBranchList(out), res, err
+}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/repository/commits?%s", encode(repo), encodeCommitListOptions(opts))
 	out := []*commit{}

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -6,6 +6,7 @@ package gitlab
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -54,12 +55,16 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 }
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?search=%s&%s", encode(repo), opts.SearchTerm, encodeListOptions(opts.PageListOptions))
+	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?search=%s&%s", encode(repo), opts.SearchTerm, encodeBranchListOptions(opts))
+	dump(path)
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err
 }
-
+func dump(data interface{}) {
+	b, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Print(string(b))
+}
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/repository/commits?%s", encode(repo), encodeCommitListOptions(opts))
 	out := []*commit{}

--- a/scm/driver/gitlab/git_test.go
+++ b/scm/driver/gitlab/git_test.go
@@ -206,6 +206,40 @@ func TestGitListBranches(t *testing.T) {
 	t.Run("Page", testPage(res))
 }
 
+func TestGitListBranchesWithBranchFilter(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/diaspora/diaspora/repository/branches").
+		MatchParam("page", "1").
+		MatchParam("per_page", "30").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		SetHeaders(mockPageHeaders).
+		File("testdata/branchesFilter.json")
+
+	client := NewDefault()
+	got, res, err := client.Git.ListBranchesWithBranchFilter(context.Background(), "diaspora/diaspora", "", scm.ListOptions{Page: 1, Size: 30})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := []*scm.Reference{}
+	raw, _ := ioutil.ReadFile("testdata/branchesFilter.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	t.Run("Request", testRequest(res))
+	t.Run("Rate", testRate(res))
+	t.Run("Page", testPage(res))
+}
+
 func TestGitListTags(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/gitlab/testdata/branchesFilter.json
+++ b/scm/driver/gitlab/testdata/branchesFilter.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "master",
+    "merged": false,
+    "protected": true,
+    "developers_can_push": false,
+    "developers_can_merge": false,
+    "commit": {
+      "author_email": "john@example.com",
+      "author_name": "John Smith",
+      "authored_date": "2012-06-27T05:51:39-07:00",
+      "committed_date": "2012-06-28T03:44:20-07:00",
+      "committer_email": "john@example.com",
+      "committer_name": "John Smith",
+      "id": "7b5c3cc8be40ee161ae89a06bba6229da1032a0c",
+      "short_id": "7b5c3cc",
+      "title": "add projects API",
+      "message": "add projects API",
+      "parent_ids": [
+        "4ad91d3c1144c406e50c7b33bae684bd6837faf8"
+      ]
+    }
+  },
+  {
+    "name": "master-patch",
+    "merged": false,
+    "protected": true,
+    "developers_can_push": false,
+    "developers_can_merge": false,
+    "commit": {
+      "author_email": "john@example.com",
+      "author_name": "John Smith",
+      "authored_date": "2012-06-27T05:51:39-07:00",
+      "committed_date": "2012-06-28T03:44:20-07:00",
+      "committer_email": "john@example.com",
+      "committer_name": "John Smith",
+      "id": "7b5c3cc8be40ee161ae89a06bba6229da1032a0d",
+      "short_id": "7b5c3cc",
+      "title": "add projects API",
+      "message": "add projects API",
+      "parent_ids": [
+        "4ad91d3c1144c406e50c7b33bae684bd6837faf9"
+      ]
+    }
+  }
+]

--- a/scm/driver/gitlab/testdata/branchesFilter.json.golden
+++ b/scm/driver/gitlab/testdata/branchesFilter.json.golden
@@ -1,0 +1,12 @@
+[
+    {
+        "Name": "master",
+        "Path": "refs/heads/master",
+        "Sha": "7b5c3cc8be40ee161ae89a06bba6229da1032a0c"
+    },
+    {
+        "Name": "master-patch",
+        "Path": "refs/heads/master-patch",
+        "Sha": "7b5c3cc8be40ee161ae89a06bba6229da1032a0d"
+    }
+]

--- a/scm/driver/gitlab/util.go
+++ b/scm/driver/gitlab/util.go
@@ -24,6 +24,20 @@ func encodePath(s string) string {
 	return strings.Replace(url.PathEscape(s), ".", "%2E", -1)
 }
 
+func encodeBranchListOptions(opts scm.BranchListOptions) string {
+	params := url.Values{}
+	if opts.SearchTerm != "" {
+		params.Set("search", opts.SearchTerm)
+	}
+	if opts.PageListOptions.Page != 0 {
+		params.Set("page", strconv.Itoa(opts.PageListOptions.Page))
+	}
+	if opts.PageListOptions.Size != 0 {
+		params.Set("pagelen", strconv.Itoa(opts.PageListOptions.Size))
+	}
+	return params.Encode()
+}
+
 func encodeListOptions(opts scm.ListOptions) string {
 	params := url.Values{}
 	if opts.Page != 0 {

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -27,10 +27,6 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 	return convertBranch(out), res, err
 }
 
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	return s.ListBranches(ctx, repo, opts)
-}
-
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	// github and gitlab permit fetching a commit by sha
 	// or branch. This code emulates the github and gitlab
@@ -51,7 +47,7 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListBranches(ctx context.Context, repo string, _ scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("api/v1/repos/%s/branches", repo)
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -27,6 +27,10 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 	return convertBranch(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	return s.ListBranches(ctx, repo, opts)
+}
+
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	// github and gitlab permit fetching a commit by sha
 	// or branch. This code emulates the github and gitlab

--- a/scm/driver/harness/git.go
+++ b/scm/driver/harness/git.go
@@ -36,6 +36,10 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 	return convertBranch(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	return s.ListBranches(ctx, repo, opts)
+}
+
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	harnessURI := buildHarnessURI(s.client.account, s.client.organization, s.client.project, repo)
 	path := fmt.Sprintf("api/v1/repos/%s/commits/%s", harnessURI, ref)

--- a/scm/driver/harness/git.go
+++ b/scm/driver/harness/git.go
@@ -36,10 +36,6 @@ func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Re
 	return convertBranch(out), res, err
 }
 
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	return s.ListBranches(ctx, repo, opts)
-}
-
 func (s *gitService) FindCommit(ctx context.Context, repo, ref string) (*scm.Commit, *scm.Response, error) {
 	harnessURI := buildHarnessURI(s.client.account, s.client.organization, s.client.project, repo)
 	path := fmt.Sprintf("api/v1/repos/%s/commits/%s", harnessURI, ref)
@@ -52,9 +48,9 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	harnessURI := buildHarnessURI(s.client.account, s.client.organization, s.client.project, repo)
-	path := fmt.Sprintf("api/v1/repos/%s/branches?%s", harnessURI, encodeListOptions(opts))
+	path := fmt.Sprintf("api/v1/repos/%s/branches?%s", harnessURI, encodeListOptions(opts.PageListOptions))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -70,18 +70,9 @@ func (s *gitService) FindTag(ctx context.Context, repo, tag string) (*scm.Refere
 	return nil, res, scm.ErrNotFound
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?%s", namespace, name, encodeListOptions(opts))
-	out := new(branches)
-	res, err := s.client.do(ctx, "GET", path, nil, out)
-	copyPagination(out.pagination, res)
-	return convertBranchList(out), res, err
-}
-
-func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	namespace, name := scm.Split(repo)
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?filterText=%s&%s", namespace, name, branch, encodeListOptions(opts))
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?filterText=%s&%s", namespace, name, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -73,7 +73,7 @@ func (s *gitService) FindTag(ctx context.Context, repo, tag string) (*scm.Refere
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?=%s", namespace, name, encodeBranchListOptions(opts))
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?%s", namespace, name, encodeBranchListOptions(opts))
 	dump(path)
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -6,6 +6,7 @@ package stash
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -72,11 +73,16 @@ func (s *gitService) FindTag(ctx context.Context, repo, tag string) (*scm.Refere
 
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?filterText=%s&%s", namespace, name, opts.SearchTerm, encodeListOptions(opts.PageListOptions))
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?=%s", namespace, name, encodeBranchListOptions(opts))
+	dump(path)
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)
 	return convertBranchList(out), res, err
+}
+func dump(data interface{}) {
+	b, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Print(string(b))
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -81,7 +81,7 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Lis
 
 func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?%s&filterText=%s", namespace, name, encodeListOptions(opts), branch)
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?filterText=%s&%s", namespace, name, branch, encodeListOptions(opts))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -6,7 +6,6 @@ package stash
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -74,15 +73,10 @@ func (s *gitService) FindTag(ctx context.Context, repo, tag string) (*scm.Refere
 func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.BranchListOptions) ([]*scm.Reference, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?%s", namespace, name, encodeBranchListOptions(opts))
-	dump(path)
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)
 	return convertBranchList(out), res, err
-}
-func dump(data interface{}) {
-	b, _ := json.MarshalIndent(data, "", "  ")
-	fmt.Print(string(b))
 }
 
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -79,6 +79,15 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.Lis
 	return convertBranchList(out), res, err
 }
 
+func (s *gitService) ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	namespace, name := scm.Split(repo)
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?%s&filterText=%s", namespace, name, encodeListOptions(opts), branch)
+	out := new(branches)
+	res, err := s.client.do(ctx, "GET", path, nil, out)
+	copyPagination(out.pagination, res)
+	return convertBranchList(out), res, err
+}
+
 func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.CommitListOptions) ([]*scm.Commit, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
 	var requestPath string

--- a/scm/driver/stash/git_test.go
+++ b/scm/driver/stash/git_test.go
@@ -147,6 +147,35 @@ func TestGitListBranches(t *testing.T) {
 	// t.Run("Page", testPage(res))
 }
 
+func TestGitListBranchesWithBranchFilter(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/branches").
+		MatchParam("filterText", "mast").
+		MatchParam("limit", "30").
+		Reply(200).
+		Type("application/json").
+		File("testdata/branchesFilter.json")
+
+	client, _ := New("http://example.com:7990")
+	got, _, err := client.Git.ListBranchesWithBranchFilter(context.Background(), "PRJ/my-repo", "mast", scm.ListOptions{Page: 1, Size: 30})
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := []*scm.Reference{}
+	raw, _ := ioutil.ReadFile("testdata/branchesFilter.json.golden")
+	_ = json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+	//
+	// t.Run("Page", testPage(res))
+}
+
 func TestGitListTags(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/stash/testdata/branchesFilter.json
+++ b/scm/driver/stash/testdata/branchesFilter.json
@@ -1,0 +1,24 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "type": "BRANCH",
+      "latestCommit": "11ce869211917dd65610e70fcee454943b35ac6e",
+      "latestChangeset": "11ce869211917dd65610e70fcee454943b35ac6e",
+      "isDefault": true
+    },
+    {
+      "id": "refs/heads/master-patch",
+      "displayId": "master-patch",
+      "type": "BRANCH",
+      "latestCommit": "11ce869211917dd65610e70fcee454943b35ac6f",
+      "latestChangeset": "11ce869211917dd65610e70fcee454943b35ac6f",
+      "isDefault": true
+    }
+  ],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/branchesFilter.json.golden
+++ b/scm/driver/stash/testdata/branchesFilter.json.golden
@@ -1,0 +1,12 @@
+[
+    {
+        "Name": "master",
+        "Path": "refs/heads/master",
+        "Sha": "11ce869211917dd65610e70fcee454943b35ac6e"
+    },
+   {
+        "Name": "master-patch",
+        "Path": "refs/heads/master-patch",
+        "Sha": "11ce869211917dd65610e70fcee454943b35ac6f"
+    }
+]

--- a/scm/driver/stash/util.go
+++ b/scm/driver/stash/util.go
@@ -6,10 +6,9 @@ package stash
 
 import (
 	"errors"
+	"github.com/drone/go-scm/scm"
 	"net/url"
 	"strconv"
-
-	"github.com/drone/go-scm/scm"
 )
 
 func encodeListOptions(opts scm.ListOptions) string {
@@ -21,6 +20,20 @@ func encodeListOptions(opts scm.ListOptions) string {
 	}
 	if opts.Size != 0 {
 		params.Set("limit", strconv.Itoa(opts.Size))
+	}
+	return params.Encode()
+}
+
+func encodeBranchListOptions(opts scm.BranchListOptions) string {
+	params := url.Values{}
+	if opts.SearchTerm != "" {
+		params.Set("filterText", opts.SearchTerm)
+	}
+	if opts.PageListOptions.Page != 0 {
+		params.Set("page", strconv.Itoa(opts.PageListOptions.Page))
+	}
+	if opts.PageListOptions.Size != 0 {
+		params.Set("pagelen", strconv.Itoa(opts.PageListOptions.Size))
 	}
 	return params.Encode()
 }

--- a/scm/git.go
+++ b/scm/git.go
@@ -71,10 +71,7 @@ type (
 		FindTag(ctx context.Context, repo, name string) (*Reference, *Response, error)
 
 		// ListBranches returns a list of git branches.
-		ListBranches(ctx context.Context, repo string, opts ListOptions) ([]*Reference, *Response, error)
-
-		// ListBranchesWithBranchFilter returns a list of git branches after filtering based on branch passed
-		ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts ListOptions) ([]*Reference, *Response, error)
+		ListBranches(ctx context.Context, repo string, opts BranchListOptions) ([]*Reference, *Response, error)
 
 		// ListCommits returns a list of git commits.
 		ListCommits(ctx context.Context, repo string, opts CommitListOptions) ([]*Commit, *Response, error)

--- a/scm/git.go
+++ b/scm/git.go
@@ -73,6 +73,9 @@ type (
 		// ListBranches returns a list of git branches.
 		ListBranches(ctx context.Context, repo string, opts ListOptions) ([]*Reference, *Response, error)
 
+		// ListBranchesWithBranchFilter returns a list of git branches after filtering based on branch passed
+		ListBranchesWithBranchFilter(ctx context.Context, repo string, branch string, opts ListOptions) ([]*Reference, *Response, error)
+
 		// ListCommits returns a list of git commits.
 		ListCommits(ctx context.Context, repo string, opts CommitListOptions) ([]*Commit, *Response, error)
 


### PR DESCRIPTION
Have added code for supporting text based branch filtration for the following git providers:
1. Bitbucket cloud
2. Bitbucket server
3. Azure
4. Gitlab
Note: Github does not provide support for text based search.

Have tested out string based search all the above providers. For the other drivers that implement the GitService interface, have called the listBranches method which means that its not filtering based on any branch being passed.
