### PR TITLE
Added support for branch names containing '&' and '#' for GetFile Operations.

### DIFF
--- a/scm/driver/azure/content.go
+++ b/scm/driver/azure/content.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/url"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -21,8 +22,9 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	if s.client.project == "" {
 		return nil, nil, ProjectRequiredError()
 	}
+	urlEncodedRef := url.QueryEscape(ref)
 	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/items?path=%s&includeContent=true&$format=json", s.client.owner, s.client.project, repo, path)
-	endpoint += generateURIFromRef(ref)
+	endpoint += generateURIFromRef(urlEncodedRef)
 	endpoint += "&api-version=6.0"
 	out := new(content)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)

--- a/scm/driver/azure/content_test.go
+++ b/scm/driver/azure/content_test.go
@@ -17,6 +17,7 @@ func TestContentFind(t *testing.T) {
 	gock.New("https:/dev.azure.com/").
 		Get("/ORG/PROJ/_apis/git/repositories/REPOID/items").
 		MatchParam("path", "README").
+		MatchParam("versionDescriptor.version", "b1&b2").
 		Reply(200).
 		Type("application/json").
 		File("testdata/content.json")
@@ -26,7 +27,7 @@ func TestContentFind(t *testing.T) {
 		context.Background(),
 		"REPOID",
 		"README",
-		"",
+		"b1&b2",
 	)
 	if err != nil {
 		t.Error(err)

--- a/scm/driver/bitbucket/content.go
+++ b/scm/driver/bitbucket/content.go
@@ -18,10 +18,8 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
-	fmt.Println("ref->", ref)
 	urlEncodedRef := url.QueryEscape(ref)
 	endpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s", repo, urlEncodedRef, path)
-	fmt.Println("endpoint->", endpoint)
 	out := new(bytes.Buffer)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	content := &scm.Content{

--- a/scm/driver/bitbucket/content.go
+++ b/scm/driver/bitbucket/content.go
@@ -21,6 +21,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	fmt.Println("ref->", ref)
 	urlEncodedRef := url.QueryEscape(ref)
 	endpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s", repo, urlEncodedRef, path)
+	fmt.Println("endpoint->", endpoint)
 	out := new(bytes.Buffer)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	content := &scm.Content{
@@ -30,7 +31,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	if err != nil {
 		return content, res, err
 	}
-	metaEndpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s?format=meta", repo, ref, path)
+	metaEndpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s?format=meta", repo, urlEncodedRef, path)
 	metaOut := new(metaContent)
 	metaRes, metaErr := s.client.do(ctx, "GET", metaEndpoint, nil, metaOut)
 	if metaErr == nil {

--- a/scm/driver/bitbucket/content.go
+++ b/scm/driver/bitbucket/content.go
@@ -18,6 +18,7 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
+	fmt.Println("ref->", ref)
 	urlEncodedRef := url.QueryEscape(ref)
 	endpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s", repo, urlEncodedRef, path)
 	out := new(bytes.Buffer)

--- a/scm/driver/bitbucket/content.go
+++ b/scm/driver/bitbucket/content.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -17,7 +18,8 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
-	endpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s", repo, ref, path)
+	urlEncodedRef := url.QueryEscape(ref)
+	endpoint := fmt.Sprintf("/2.0/repositories/%s/src/%s/%s", repo, urlEncodedRef, path)
 	out := new(bytes.Buffer)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	content := &scm.Content{

--- a/scm/driver/github/content.go
+++ b/scm/driver/github/content.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/url"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -17,7 +18,8 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
-	endpoint := fmt.Sprintf("repos/%s/contents/%s?ref=%s", repo, path, ref)
+	urlEncodedRef := url.QueryEscape(ref)
+	endpoint := fmt.Sprintf("repos/%s/contents/%s?ref=%s", repo, path, urlEncodedRef)
 	out := new(content)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	raw, _ := base64.StdEncoding.DecodeString(out.Content)

--- a/scm/driver/gitlab/content.go
+++ b/scm/driver/gitlab/content.go
@@ -19,7 +19,8 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
-	endpoint := fmt.Sprintf("api/v4/projects/%s/repository/files/%s?ref=%s", encode(repo), encodePath(path), ref)
+	urlEncodedRef := url.QueryEscape(ref)
+	endpoint := fmt.Sprintf("api/v4/projects/%s/repository/files/%s?ref=%s", encode(repo), encodePath(path), urlEncodedRef)
 	out := new(content)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	raw, berr := base64.StdEncoding.DecodeString(out.Content)

--- a/scm/driver/harness/content.go
+++ b/scm/driver/harness/content.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"time"
+	"net/url"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -18,8 +19,9 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
+	urlEncodedRef := url.QueryEscape(ref)
 	repo = buildHarnessURI(s.client.account, s.client.organization, s.client.project, repo)
-	endpoint := fmt.Sprintf("api/v1/repos/%s/content/%s?git_ref=%s&include_commit=true", repo, path, ref)
+	endpoint := fmt.Sprintf("api/v1/repos/%s/content/%s?git_ref=%s&include_commit=true", repo, path, urlEncodedRef)
 	out := new(fileContent)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	// decode raw output content

--- a/scm/driver/harness/content.go
+++ b/scm/driver/harness/content.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"time"
-	"net/url"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -19,9 +18,8 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
-	urlEncodedRef := url.QueryEscape(ref)
 	repo = buildHarnessURI(s.client.account, s.client.organization, s.client.project, repo)
-	endpoint := fmt.Sprintf("api/v1/repos/%s/content/%s?git_ref=%s&include_commit=true", repo, path, urlEncodedRef)
+	endpoint := fmt.Sprintf("api/v1/repos/%s/content/%s?git_ref=%s&include_commit=true", repo, path, ref)
 	out := new(fileContent)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	// decode raw output content

--- a/scm/driver/stash/content.go
+++ b/scm/driver/stash/content.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -17,8 +18,9 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
+	urlEncodedRef := url.QueryEscape(ref)
 	namespace, name := scm.Split(repo)
-	endpoint := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/raw/%s?at=%s", namespace, name, path, ref)
+	endpoint := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/raw/%s?at=%s", namespace, name, path, urlEncodedRef)
 	out := new(bytes.Buffer)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
 	return &scm.Content{

--- a/scm/driver/stash/content_test.go
+++ b/scm/driver/stash/content_test.go
@@ -40,6 +40,28 @@ func TestContentFind(t *testing.T) {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
 	}
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/raw/README").
+		MatchParam("at", "b1&b2").
+		Reply(200).
+		Type("text/plain").
+		File("testdata/content.txt")
+
+	client, _ = New("http://example.com:7990")
+	got, _, err = client.Contents.Find(context.Background(), "PRJ/my-repo", "README", "b1&b2")
+	if err != nil {
+		t.Error(err)
+	}
+
+	want = new(scm.Content)
+	raw, _ = ioutil.ReadFile("testdata/content.json.golden")
+	_ = json.Unmarshal(raw, want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
 }
 
 func TestContentCreate(t *testing.T) {


### PR DESCRIPTION
Change: Encoded Ref(which carries branch) to URL-encoding for Get File Operations for Github and Azure Git Provider.
Impact: All getFile flows for all supported Git Providers.

Testing:
Azure: Tested with branches "b1&b2" and "#123", both didn't fetch the fileContents before the fix, after fix response was correct.
Github: Tested with branches "b1&b2" and "#123", both didn't fetch the fileContents before the fix, after fix response was correct.
Gitlab: Tested with branches "b1&b2" and "#123", both didn't fetch the fileContents before the fix, after fix response was correct.
BB: Tested with branches "b1&b2" and "#123", both didn't fetch the fileContents before the fix, after fix response was correct.
BB on prem: Tested with branches "b1&b2" and "#123", both didn't fetch the fileContents before the fix, after fix response was correct.