### PR TITLE
[feat]: [CDS-93606]: Fix the query param for github list repos

### DIFF
--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -29,7 +29,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
-			sb.WriteString("in:name+user:")
+			sb.WriteString(" in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {
 			sb.WriteString("q=")


### PR DESCRIPTION
Fixed the GitHub list repos search term query params. Have tested out the endpoint with and without the filter search term