### PR TITLE
[feat]: [CDS-93606]: Added Support for search term in For List Repo Operations.

### DIFF
--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"fmt"
 
 	"github.com/drone/go-scm/scm"
 )

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -29,7 +29,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
-			sb.WriteString("in:name+user:")
+			sb.WriteString(" in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {
 			sb.WriteString("q=")
@@ -47,8 +47,9 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	
-	return url.QueryEscape(sb.String())
+	urlEncodedRepoListOptions := url.QueryEscape(sb.String())
+	fmt.Println(urlEncodedRepoListOptions)
+	return urlEncodedRepoListOptions
 }
 
 func encodeCommitListOptions(opts scm.CommitListOptions) string {

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -30,7 +30,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
-			sb.WriteString(" in:name+user:")
+			sb.WriteString("%20in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {
 			sb.WriteString("q=")
@@ -48,9 +48,8 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	urlEncodedRepoListOptions := url.QueryEscape(sb.String())
-	fmt.Println(urlEncodedRepoListOptions)
-	return urlEncodedRepoListOptions
+	fmt.Println(sb.String())
+	return sb.String()
 }
 
 func encodeCommitListOptions(opts scm.CommitListOptions) string {

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -48,7 +49,8 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	url := url.QueryEscape(sb.String())
+	url := encodeString(sb.String())
+	// url := url.QueryEscape(sb.String())
 	fmt.Println(url)
 	return url
 }
@@ -132,4 +134,33 @@ func encodeReleaseListOptions(opts scm.ReleaseListOptions) string {
 		params.Set("state", "closed")
 	}
 	return params.Encode()
+}
+
+func encodeString(s string) string {
+	var encoded strings.Builder
+
+	for _, r := range s {
+		if shouldEscape(r) {
+			encoded.WriteString(fmt.Sprintf("%%%02X", r))
+		} else {
+			encoded.WriteRune(r)
+		}
+	}
+
+	return encoded.String()
+}
+
+func shouldEscape(r rune) bool {
+	switch {
+	case r >= 'A' && r <= 'Z':
+		return false
+	case r >= 'a' && r <= 'z':
+		return false
+	case r >= '0' && r <= '9':
+		return false
+	case r == '-', '_', '.', '~':
+		return false
+	default:
+		return true
+	}
 }

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -29,6 +29,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
+			// %20 is urlEncoding of blank space.
 			sb.WriteString("%20in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"fmt"
-	"unicode/utf8"
 
 	"github.com/drone/go-scm/scm"
 )

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"fmt"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -48,7 +47,6 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	fmt.Println(sb.String())
 	return sb.String()
 }
 

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -30,7 +30,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
-			sb.WriteString(" in:name+user:")
+			sb.WriteString("+in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {
 			sb.WriteString("q=")
@@ -48,10 +48,8 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	url := encodeString(sb.String())
-	// url := url.QueryEscape(sb.String())
-	fmt.Println(url)
-	return url
+	fmt.Println(sb.string())
+	return sb.string()
 }
 
 func encodeCommitListOptions(opts scm.CommitListOptions) string {
@@ -133,33 +131,4 @@ func encodeReleaseListOptions(opts scm.ReleaseListOptions) string {
 		params.Set("state", "closed")
 	}
 	return params.Encode()
-}
-
-func encodeString(s string) string {
-	var encoded strings.Builder
-
-	for _, r := range s {
-		if shouldEscape(r) {
-			encoded.WriteString(fmt.Sprintf("%%%02X", r))
-		} else {
-			encoded.WriteRune(r)
-		}
-	}
-
-	return encoded.String()
-}
-
-func shouldEscape(r rune) bool {
-	switch {
-	case r >= 'A' && r <= 'Z':
-		return false
-	case r >= 'a' && r <= 'z':
-		return false
-	case r >= '0' && r <= '9':
-		return false
-	case r == '-', '_', '.', '~':
-		return false
-	default:
-		return true
-	}
 }

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -30,7 +30,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
-			sb.WriteString("in:name+user:")
+			sb.WriteString(" in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {
 			sb.WriteString("q=")

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -48,8 +48,8 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	fmt.Println(sb.string())
-	return sb.string()
+	fmt.Println(sb.String())
+	return sb.String()
 }
 
 func encodeCommitListOptions(opts scm.CommitListOptions) string {

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -47,7 +47,8 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	return sb.String()
+	
+	return url.QueryEscape(sb.String())
 }
 
 func encodeCommitListOptions(opts scm.CommitListOptions) string {

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"fmt"
 
 	"github.com/drone/go-scm/scm"
 )
@@ -29,8 +30,7 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 		if opts.RepoSearchTerm.RepoName != "" {
 			sb.WriteString("q=")
 			sb.WriteString(opts.RepoSearchTerm.RepoName)
-			// %20 is urlEncoding of blank space.
-			sb.WriteString("%20in:name+user:")
+			sb.WriteString("in:name+user:")
 			sb.WriteString(opts.RepoSearchTerm.User)
 		} else {
 			sb.WriteString("q=")
@@ -48,7 +48,9 @@ func encodeRepoListOptions(opts scm.RepoListOptions) string {
 			sb.WriteString(strconv.Itoa(opts.ListOptions.Size))
 		}
 	}
-	return sb.String()
+	url := url.QueryEscape(sb.String())
+	fmt.Println(url)
+	return url
 }
 
 func encodeCommitListOptions(opts scm.CommitListOptions) string {


### PR DESCRIPTION
## Issue:
- Github support search term in For List Repo Operations but our flow was failing for the same. Issue was pinpointes at the go-scm library level.

## Changes:
- Added Blank Space in Url Encoded Format to build the correct Url path.

## Testing:
- Changes were tested for various search terms on my Github Account with user name "senjucanon2": 
- - Search term "test" -> fetched 3 results: "test-repo", "test-repo2", "terraform-test".
- - Search term "test-repo" -> fetched 2 results: "test-repo", "test-repo2"
- - Search term "terraform" -> fetched 1 result: "terraform-test".
- - Invalid Search term -> fetched 0 result.

