### PR TITLE
[fix]: [PIPE-20649]: Fixed Branch Names in Body for CRUD operations For AzureFlows

### DIFF
--- a/scm/driver/azure/azure.go
+++ b/scm/driver/azure/azure.go
@@ -122,8 +122,5 @@ func ProjectRequiredError() error {
 }
 
 func SanitizeBranchName(name string) string {
-	if strings.Contains(name, "/") {
-		return name
-	}
 	return "refs/heads/" + name
 }

--- a/scm/driver/azure/azure_test.go
+++ b/scm/driver/azure/azure_test.go
@@ -54,11 +54,11 @@ func TestSanitizeBranchName(t *testing.T) {
 			"refs/heads/master",
 		},
 		{
-			"refs/heads/master",
+			"feature/main-patch",
 			args{
-				"refs/heads/master",
+				"feature/main-patch",
 			},
-			"refs/heads/master",
+			"refs/heads/feature/main-patch",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Context:
- Whenever the branch name contains '/' in it , the Create, Update operations fails in-case of Azure. Azure returns that the name of branch is not valid.

## Issue:
- Branch names needs to be prepended by refs/heads whenever passes in body of requests. And it was skipped for branch having '/' in names.

## Testing:
- Have successfully validated create and update operations for Harness with Azure Git Provider.
