### PR TITLE
fix: pass gitlab mergerequest param via json body

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -60,14 +60,23 @@ func (s *pullService) ListCommits(ctx context.Context, repo string, number int, 
 }
 
 func (s *pullService) Create(ctx context.Context, repo string, input *scm.PullRequestInput) (*scm.PullRequest, *scm.Response, error) {
-	in := url.Values{}
-	in.Set("title", input.Title)
-	in.Set("description", input.Body)
-	in.Set("source_branch", input.Source)
-	in.Set("target_branch", input.Target)
-	path := fmt.Sprintf("api/v4/projects/%s/merge_requests?%s", encode(repo), in.Encode())
+	// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
+	in := struct {
+		Title        string `json:"title"`
+		Description  string `json:"description"`
+		SourceBranch string `json:"source_branch"`
+		TargetBranch string `json:"target_branch"`
+	}{
+		Title:        input.Title,
+		Description:  input.Body,
+		SourceBranch: input.Source,
+		TargetBranch: input.Target,
+	}
+
+	path := fmt.Sprintf("api/v4/projects/%s/merge_requests", encode(repo))
+
 	out := new(pr)
-	res, err := s.client.do(ctx, "POST", path, nil, out)
+	res, err := s.client.do(ctx, "POST", path, in, out)
 	return convertPullRequest(out), res, err
 }
 

--- a/scm/driver/gitlab/pr_test.go
+++ b/scm/driver/gitlab/pr_test.go
@@ -162,10 +162,6 @@ func TestPullCreate(t *testing.T) {
 
 	gock.New("https://gitlab.com").
 		Post("/api/v4/projects/diaspora/diaspora/merge_requests").
-		MatchParam("title", input.Title).
-		MatchParam("description", input.Body).
-		MatchParam("source_branch", input.Source).
-		MatchParam("target_branch", input.Target).
 		Reply(201).
 		Type("application/json").
 		SetHeaders(mockHeaders).


### PR DESCRIPTION
When opening a merge request on GitLab, the current implementation pass all the parameters via the URL parameters instead of using the HTTP body.
The problem is that the amount of information that can be provided via URL parameter is very limited, which lead to not being able to create a merge request.

## Test

On top of the unit test, I tested this change on a different project:

<details><summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/010b8082-62ce-49fe-b1b7-3f3c7e6da0e6)

</details> 

## Additional Information

### Potential improvement

I also noticed that function `⁣CreateComment` use URL parameter and I think it could also be improved but I am not using that function on my project