### PR TITLE
feat:[CDS-101592]: Add support for parsing Gitlab System Hooks

### DIFF
--- a/scm/driver/gitlab/webhook_test.go
+++ b/scm/driver/gitlab/webhook_test.go
@@ -38,6 +38,18 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/branch_delete.json.golden",
 			obj:    new(scm.BranchHook),
 		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/branch_create.json",
+			after:  "testdata/webhooks/branch_create.json.golden",
+			obj:    new(scm.PushHook),
+		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/branch_delete.json",
+			after:  "testdata/webhooks/branch_delete.json.golden",
+			obj:    new(scm.BranchHook),
+		},
 		// tag hooks
 		{
 			event:  "Tag Push Hook",
@@ -51,9 +63,27 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/tag_delete.json.golden",
 			obj:    new(scm.TagHook),
 		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/tag_create.json",
+			after:  "testdata/webhooks/tag_create.json.golden",
+			obj:    new(scm.PushHook),
+		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/tag_delete.json",
+			after:  "testdata/webhooks/tag_delete.json.golden",
+			obj:    new(scm.TagHook),
+		},
 		// push hooks
 		{
 			event:  "Push Hook",
+			before: "testdata/webhooks/push.json",
+			after:  "testdata/webhooks/push.json.golden",
+			obj:    new(scm.PushHook),
+		},
+		{
+			event:  "System Hook",
 			before: "testdata/webhooks/push.json",
 			after:  "testdata/webhooks/push.json.golden",
 			obj:    new(scm.PushHook),
@@ -79,6 +109,13 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/pull_request_create.json.golden",
 			obj:    new(scm.PullRequestHook),
 		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/pull_request_create.json",
+			after:  "testdata/webhooks/pull_request_create.json.golden",
+			obj:    new(scm.PullRequestHook),
+		},
+
 		// {
 		// 	event:  "Merge Request Hook",
 		// 	before: "testdata/webhooks/pull_request_edited.json",
@@ -115,9 +152,39 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/pull_request_merge.json.golden",
 			obj:    new(scm.PullRequestHook),
 		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/pull_request_close.json",
+			after:  "testdata/webhooks/pull_request_close.json.golden",
+			obj:    new(scm.PullRequestHook),
+		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/pull_request_review_ready.json",
+			after:  "testdata/webhooks/pull_request_review_ready.json.golden",
+			obj:    new(scm.PullRequestHook),
+		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/pull_request_reopen.json",
+			after:  "testdata/webhooks/pull_request_reopen.json.golden",
+			obj:    new(scm.PullRequestHook),
+		},
+		{
+			event:  "System Hook",
+			before: "testdata/webhooks/pull_request_merge.json",
+			after:  "testdata/webhooks/pull_request_merge.json.golden",
+			obj:    new(scm.PullRequestHook),
+		},
 		// Note hook for Gitlab Merge Request comment
 		{
 			event:  "Note Hook",
+			before: "testdata/webhooks/merge_request_comment_create.json",
+			after:  "testdata/webhooks/merge_request_comment_create.json.golden",
+			obj:    new(scm.IssueCommentHook),
+		},
+		{
+			event:  "System Hook",
 			before: "testdata/webhooks/merge_request_comment_create.json",
 			after:  "testdata/webhooks/merge_request_comment_create.json.golden",
 			obj:    new(scm.IssueCommentHook),


### PR DESCRIPTION
This pull request adds support for GitLab System Hooks, which send notifications about various events (like pushes, tags, and merge requests) happening in a GitLab repository. These hooks allow us to handle important repository events more effectively.

Added `parseSystemHook` function:
* This function processes different types of events coming from GitLab System Hooks by checking the `object_kind` field in the payload.

It currently supports the following event types:
* Push and Tag Push events: These are handled by the existing parsePushHook function.
* Merge Request events: Handled by the existing parsePullRequestHook function.
* Comments (Notes): Handled by parseIssueCommentHook.
* Events like Issue or unknown events will return an error indicating that the event is not recognized.

More about System Hooks - 
https://docs.gitlab.com/ee/administration/system_hooks.html