### PR TITLE
Update Bitbucket PR author login

### DIFF
--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -193,7 +193,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 			Sha:  from.Destination.Commit.Hash,
 		},
 		Author: scm.User{
-			ID:  from.Author.AccountID,
+			ID:     from.Author.AccountID,
 			Name:   from.Author.DisplayName,
 			Avatar: from.Author.Links.Avatar.Href,
 		},

--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -193,7 +193,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 			Sha:  from.Destination.Commit.Hash,
 		},
 		Author: scm.User{
-			Login:  from.Author.AccountID,
+			ID:  from.Author.AccountID,
 			Name:   from.Author.DisplayName,
 			Avatar: from.Author.Links.Avatar.Href,
 		},

--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -193,7 +193,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 			Sha:  from.Destination.Commit.Hash,
 		},
 		Author: scm.User{
-			Login:  from.Author.Nickname,
+			Login:  from.Author.UUID,
 			Name:   from.Author.DisplayName,
 			Avatar: from.Author.Links.Avatar.Href,
 		},

--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -193,7 +193,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 			Sha:  from.Destination.Commit.Hash,
 		},
 		Author: scm.User{
-			Login:  from.Author.UUID,
+			Login:  from.Author.AccountID,
 			Name:   from.Author.DisplayName,
 			Avatar: from.Author.Links.Avatar.Href,
 		},

--- a/scm/driver/bitbucket/testdata/pr.json.golden
+++ b/scm/driver/bitbucket/testdata/pr.json.golden
@@ -22,7 +22,7 @@
       "Name": "Lachlan-Vass/ios-date-picker-component-duplicate-marc-1579222909688"
     },
     "Author": {
-      "Login": "5c7c7b1a0b79db7c3e33eca2",
+      "ID": "5c7c7b1a0b79db7c3e33eca2",
       "Name": "Lachlan Vass",
       "Avatar": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5c7c7b1a0b79db7c3e33eca2/6b6b8178-0da0-4a37-b0dd-f8b5e3628eaa/128"
     },

--- a/scm/driver/bitbucket/testdata/pr.json.golden
+++ b/scm/driver/bitbucket/testdata/pr.json.golden
@@ -22,7 +22,7 @@
       "Name": "Lachlan-Vass/ios-date-picker-component-duplicate-marc-1579222909688"
     },
     "Author": {
-      "Login": "ef9d9075-f870-417f-b424-83adbc8efa54",
+      "Login": "5c7c7b1a0b79db7c3e33eca2",
       "Name": "Lachlan Vass",
       "Avatar": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5c7c7b1a0b79db7c3e33eca2/6b6b8178-0da0-4a37-b0dd-f8b5e3628eaa/128"
     },

--- a/scm/driver/bitbucket/testdata/pr.json.golden
+++ b/scm/driver/bitbucket/testdata/pr.json.golden
@@ -22,7 +22,7 @@
       "Name": "Lachlan-Vass/ios-date-picker-component-duplicate-marc-1579222909688"
     },
     "Author": {
-      "Login": "Lachlan",
+      "Login": "ef9d9075-f870-417f-b424-83adbc8efa54",
       "Name": "Lachlan Vass",
       "Avatar": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5c7c7b1a0b79db7c3e33eca2/6b6b8178-0da0-4a37-b0dd-f8b5e3628eaa/128"
     },

--- a/scm/driver/bitbucket/testdata/prs.json.golden
+++ b/scm/driver/bitbucket/testdata/prs.json.golden
@@ -23,7 +23,7 @@
       "Name": "Lachlan-Vass/ios-date-picker-component-duplicate-marc-1579222909688"
     },
     "Author": {
-      "Login": "ef9d9075-f870-417f-b424-83adbc8efa54",
+      "Login": "5c7c7b1a0b79db7c3e33eca2",
       "Name": "Lachlan Vass",
       "Avatar": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5c7c7b1a0b79db7c3e33eca2/6b6b8178-0da0-4a37-b0dd-f8b5e3628eaa/128"
     },

--- a/scm/driver/bitbucket/testdata/prs.json.golden
+++ b/scm/driver/bitbucket/testdata/prs.json.golden
@@ -23,7 +23,7 @@
       "Name": "Lachlan-Vass/ios-date-picker-component-duplicate-marc-1579222909688"
     },
     "Author": {
-      "Login": "Lachlan",
+      "Login": "ef9d9075-f870-417f-b424-83adbc8efa54",
       "Name": "Lachlan Vass",
       "Avatar": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5c7c7b1a0b79db7c3e33eca2/6b6b8178-0da0-4a37-b0dd-f8b5e3628eaa/128"
     },

--- a/scm/driver/bitbucket/testdata/prs.json.golden
+++ b/scm/driver/bitbucket/testdata/prs.json.golden
@@ -23,7 +23,7 @@
       "Name": "Lachlan-Vass/ios-date-picker-component-duplicate-marc-1579222909688"
     },
     "Author": {
-      "Login": "5c7c7b1a0b79db7c3e33eca2",
+      "ID": "5c7c7b1a0b79db7c3e33eca2",
       "Name": "Lachlan Vass",
       "Avatar": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5c7c7b1a0b79db7c3e33eca2/6b6b8178-0da0-4a37-b0dd-f8b5e3628eaa/128"
     },


### PR DESCRIPTION
Currently Bitbucket PR author login field uses user's nickname which is not unique. I suggest to use accountID or UUID instead as explained here:
https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/