### PR TITLE
Add modify field in scm.Change

### DIFF
--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -247,10 +247,11 @@ func convertDiffstats(from *diffstats) []*scm.Change {
 
 func convertDiffstat(from *diffstat) *scm.Change {
 	return &scm.Change{
-		Path:    from.Path.ToString,
-		Added:   from.Type == "ADD",
-		Renamed: from.Type == "MOVE",
-		Deleted: from.Type == "DELETE",
+		Path:     from.Path.ToString,
+		Added:    from.Type == "ADD",
+		Renamed:  from.Type == "MOVE",
+		Modified: from.Type == "MODIFY",
+		Deleted:  from.Type == "DELETE",
 	}
 }
 

--- a/scm/driver/stash/testdata/changes.json.golden
+++ b/scm/driver/stash/testdata/changes.json.golden
@@ -2,24 +2,28 @@
     {
         "Path": ".gitignore",
         "Added": false,
+        "Modified": false,
         "Renamed": false,
         "Deleted": true
     },
     {
         "Path": "COPYING",
         "Added": false,
+        "Modified": true,
         "Renamed": false,
         "Deleted": false
     },
     {
         "Path": "README.md",
         "Added": false,
+        "Modified": false,
         "Renamed": true,
         "Deleted": false
     },
     {
         "Path": "main.go",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     }

--- a/scm/driver/stash/testdata/compare.json.golden
+++ b/scm/driver/stash/testdata/compare.json.golden
@@ -2,24 +2,28 @@
     {
         "Path": ".gitignore",
         "Added": false,
+        "Modified": false,
         "Renamed": false,
         "Deleted": true
     },
     {
         "Path": "COPYING",
         "Added": false,
+        "Modified": true,
         "Renamed": false,
         "Deleted": false
     },
     {
         "Path": "README.md",
         "Added": false,
+        "Modified": false,
         "Renamed": true,
         "Deleted": false
     },
     {
         "Path": "main.go",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     }

--- a/scm/driver/stash/testdata/pr_change.json.golden
+++ b/scm/driver/stash/testdata/pr_change.json.golden
@@ -2,24 +2,28 @@
     {
         "Path": "COPYING",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     },
     {
         "Path": "README",
         "Added": false,
+        "Modified": false,
         "Renamed": false,
         "Deleted": true
     },
     {
         "Path": "README.md",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     },
     {
         "Path": "main.go",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     }

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -55,6 +55,7 @@ type (
 	Change struct {
 		Path         string
 		Added        bool
+		Modified     bool
 		Renamed      bool
 		Deleted      bool
 		Sha          string


### PR DESCRIPTION
file's modification status is missing in response of [Client.PullRequests.ListChanges](https://github.com/drone/go-scm/blob/d5ed63c1a5888b1378412d5d95c24c866e4bb47c/scm/driver/stash/pr.go#L47) func. This PR solves that issue.

### Before
```
{
   "Path": ".tekton/pipelinerun-1.yaml",
   "Added": true,
   "Renamed": false,
   "Deleted": false,
   "Sha": "",
   "BlobID": "",
   "PrevFilePath": ""
 }
{
   "Path": ".tekton/pipelinerun.yaml",
   "Added": false,
   "Renamed": false,
   "Deleted": false,
   "Sha": "",
   "BlobID": "",
   "PrevFilePath": ""
 }
```

### After
```
{
   "Path": ".tekton/pipelinerun-1.yaml",
   "Added": true,
   "Modified": false,
   "Renamed": false,
   "Deleted": false,
   "Sha": "",
   "BlobID": "",
   "PrevFilePath": ""
 }
{
   "Path": ".tekton/pipelinerun.yaml",
   "Added": false,
   "Modified": true,
   "Renamed": false,
   "Deleted": false,
   "Sha": "",
   "BlobID": "",
   "PrevFilePath": ""
 }
```