### PR TITLE
feat: Add ListTags to Azure

### DIFF
--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -222,7 +222,7 @@ type tag struct {
 	ObjectID string `json:"objectId"`
 	Creator  struct {
 		DisplayName string `json:"displayName"`
-		Url         string `json:"url"`
+		URL         string `json:"url"`
 		Links       struct {
 			Avatar struct {
 				Href string `json:"href"`

--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -94,7 +94,18 @@ func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.Comm
 }
 
 func (s *gitService) ListTags(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+	if s.client.project == "" {
+		return nil, nil, ProjectRequiredError()
+	}
+	endpoint := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/refs?", s.client.owner, s.client.project, repo)
+	// add tags
+	endpoint += fmt.Sprintf("filter=tags/")
+	// add target
+	endpoint += fmt.Sprintf("&api-version=7.1-preview.1")
+	out := new(tags)
+	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)
+
+	return convertTags(out.Value), res, err
 }
 
 func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
@@ -202,6 +213,29 @@ type compare struct {
 	TargetCommit string  `json:"targetCommit"`
 }
 
+type tags struct {
+	Value []*tag `json:"value"`
+	Count int    `json:"count"`
+}
+type tag struct {
+	Name     string `json:"name"`
+	ObjectID string `json:"objectId"`
+	Creator  struct {
+		DisplayName string `json:"displayName"`
+		Url         string `json:"url"`
+		Links       struct {
+			Avatar struct {
+				Href string `json:"href"`
+			} `json:"avatar"`
+		} `json:"_links"`
+		ID         string `json:"id"`
+		UniqueName string `json:"uniqueName"`
+		ImageURL   string `json:"imageUrl"`
+		Descriptor string `json:"descriptor"`
+	} `json:"creator"`
+	URL string `json:"url"`
+}
+
 func convertBranchList(from []*branch) []*scm.Reference {
 	to := []*scm.Reference{}
 	for _, v := range from {
@@ -268,4 +302,16 @@ func convertChange(from *file) *scm.Change {
 	}
 
 	return returnVal
+}
+
+func convertTags(from []*tag) []*scm.Reference {
+	var to []*scm.Reference
+	for _, v := range from {
+		to = append(to, &scm.Reference{
+			Name: scm.TrimRef(v.Name),
+			Path: scm.ExpandRef(v.Name, "refs/tags/"),
+			Sha:  v.ObjectID,
+		})
+	}
+	return to
 }

--- a/scm/driver/azure/testdata/tags.json
+++ b/scm/driver/azure/testdata/tags.json
@@ -1,0 +1,41 @@
+{
+  "value": [
+    {
+      "name": "refs/tags/v1.0.0",
+      "objectId": "23d9c1d0d6c41f1c8e08ab98a6a79c2d5ada649d",
+      "creator": {
+        "displayName": "Test User",
+        "url": "https://dev.azure.com/fabrikam/_apis/Identities/d6245f20-2af8-44f4-9451-8107cb2767db",
+        "_links": {
+          "avatar": {
+            "href": "https://dev.azure.com/fabrikam/_apis/GraphProfile/MemberAvatars/aad.YTYyNDVmMjAtMmFmOC00NGY0LTk0NTEtODEwN2NiMjc2N2Ri"
+          }
+        },
+        "id": "d6245f20-2af8-44f4-9451-8107cb2767db",
+        "uniqueName": "test@example.com",
+        "imageUrl": "https://dev.azure.com/fabrikam/_api/_common/identityImage?id=d6245f20-2af8-44f4-9451-8107cb2767db",
+        "descriptor": "aad.YTYyNDVmMjAtMmFmOC00NGY0LTk0NTEtODEwN2NiMjc2N2Ri"
+      },
+      "url": "https://dev.azure.com/fabrikam/DefaultCollection/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/refs/tags/v1.0.0"
+    },
+    {
+      "name": "refs/tags/v1.1.0",
+      "objectId": "8a9db19b5e19613c18e9059d7b9fa5d6d6a3785f",
+      "creator": {
+        "displayName": "Test User",
+        "url": "https://dev.azure.com/fabrikam/_apis/Identities/d6245f20-2af8-44f4-9451-8107cb2767db",
+        "_links": {
+          "avatar": {
+            "href": "https://dev.azure.com/fabrikam/_apis/GraphProfile/MemberAvatars/aad.YTYyNDVmMjAtMmFmOC00NGY0LTk0NTEtODEwN2NiMjc2N2Ri"
+          }
+        },
+        "id": "d6245f20-2af8-44f4-9451-8107cb2767db",
+        "uniqueName": "test@example.com",
+        "imageUrl": "https://dev.azure.com/fabrikam/_api/_common/identityImage?id=d6245f20-2af8-44f4-9451-8107cb2767db",
+        "descriptor": "aad.YTYyNDVmMjAtMmFmOC00NGY0LTk0NTEtODEwN2NiMjc2N2Ri"
+      },
+      "url": "https://dev.azure.com/fabrikam/DefaultCollection/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/refs/tags/v1.1.0"
+    }
+  ],
+  "count": 2
+}

--- a/scm/driver/azure/testdata/tags.json.golden
+++ b/scm/driver/azure/testdata/tags.json.golden
@@ -1,0 +1,12 @@
+[
+  {
+    "Name": "v1.0.0",
+    "Path": "refs/tags/v1.0.0",
+    "Sha": "23d9c1d0d6c41f1c8e08ab98a6a79c2d5ada649d"
+  },
+  {
+    "Name": "v1.1.0",
+    "Path": "refs/tags/v1.1.0",
+    "Sha": "8a9db19b5e19613c18e9059d7b9fa5d6d6a3785f"
+  }
+]


### PR DESCRIPTION
This PR adds the retrieve tags capability to the AzureCode driver. The code was implemented following the documentation: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/refs/list?view=azure-devops-rest-7.1&tabs=HTTP