### PR TITLE
feat: [PIPE-32185]: handle deprecated cross-workspace API endpoints

### DIFF
--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -27,24 +27,38 @@ func (s *organizationService) FindMembership(ctx context.Context, name, username
 }
 
 func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/workspaces?%s", encodeListRoleOptions(opts))
-	out := new(organizationList)
+	// Use /2.0/user/workspaces endpoint (replaces deprecated /2.0/workspaces)
+	path := fmt.Sprintf("2.0/user/workspaces?%s", encodeListOptions(opts))
+	out := new(workspaceAccessList)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
+	if err != nil {
+		return nil, res, err
+	}
 	copyPagination(out.pagination, res)
-	return convertOrganizationList(out), res, err
+	return convertWorkspaceAccessList(out), res, err
 }
 
-func convertOrganizationList(from *organizationList) []*scm.Organization {
+func convertWorkspaceAccessList(from *workspaceAccessList) []*scm.Organization {
 	to := []*scm.Organization{}
 	for _, v := range from.Values {
-		to = append(to, convertOrganization(v))
+		if v.Workspace != nil {
+			to = append(to, convertWorkspace(v.Workspace))
+		}
 	}
 	return to
 }
 
-type organizationList struct {
-	pagination
-	Values []*organization `json:"values"`
+func convertWorkspace(from *workspace) *scm.Organization {
+	avatar := ""
+	if from.Links.Avatar.Href != "" {
+		avatar = from.Links.Avatar.Href
+	} else {
+		avatar = fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32/", from.Slug)
+	}
+	return &scm.Organization{
+		Name:   from.Slug,
+		Avatar: avatar,
+	}
 }
 
 type organization struct {

--- a/scm/driver/bitbucket/org_test.go
+++ b/scm/driver/bitbucket/org_test.go
@@ -44,13 +44,14 @@ func TestOrganizationFind(t *testing.T) {
 func TestOrganizationList(t *testing.T) {
 	defer gock.Off()
 
+	// Uses new /2.0/user/workspaces endpoint
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces").
+		Get("/2.0/user/workspaces").
 		MatchParam("pagelen", "30").
 		MatchParam("page", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/teams.json")
+		File("testdata/user_workspaces.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Organizations.List(context.Background(), scm.ListOptions{Size: 30, Page: 1})
@@ -59,7 +60,7 @@ func TestOrganizationList(t *testing.T) {
 	}
 
 	want := []*scm.Organization{}
-	raw, _ := ioutil.ReadFile("testdata/teams.json.golden")
+	raw, _ := ioutil.ReadFile("testdata/user_workspaces.json.golden")
 	json.Unmarshal(raw, &want)
 
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -87,34 +88,85 @@ func (s *repositoryService) FindHook(ctx context.Context, repo string, id string
 
 // FindPerms returns the repository permissions.
 func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Perm, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/user/permissions/repositories?q=repository.full_name=%q", repo)
-	out := new(perms)
-	res, err := s.client.do(ctx, "GET", path, nil, out)
-	return convertPerms(out), res, err
+	// First, try to extract workspace from client's BaseURL
+	workspace := s.client.extractWorkspaceFromURL()
+
+	if workspace != "" {
+		// Workspace found in URL, use it directly with repo name
+		path := fmt.Sprintf("2.0/workspaces/%s/permissions/repositories/%s", workspace, repo)
+		out := new(workspaceRepoPerms)
+		res, err := s.client.do(ctx, "GET", path, nil, out)
+		if err != nil {
+			return nil, res, err
+		}
+		return convertWorkspaceRepoPerms(out), res, nil
+	}
+
+	// No workspace in URL - check if repo contains workspace (format: "workspace/repo_slug")
+	if strings.Contains(repo, "/") {
+		ws, repoSlug := scm.Split(repo)
+		path := fmt.Sprintf("2.0/workspaces/%s/permissions/repositories/%s", ws, repoSlug)
+		out := new(workspaceRepoPerms)
+		res, err := s.client.do(ctx, "GET", path, nil, out)
+		if err != nil {
+			return nil, res, err
+		}
+		return convertWorkspaceRepoPerms(out), res, nil
+	}
+
+	// Fallback: iterate all workspaces to find the repo
+	workspaces, err := s.client.fetchAllWorkspaces(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, ws := range workspaces {
+		path := fmt.Sprintf("2.0/workspaces/%s/permissions/repositories/%s", ws, repo)
+		out := new(workspaceRepoPerms)
+		res, err := s.client.do(ctx, "GET", path, nil, out)
+		if err == nil && len(out.Values) > 0 {
+			return convertWorkspaceRepoPerms(out), res, nil
+		}
+	}
+
+	// Repo not found in any workspace
+	return &scm.Perm{}, nil, nil
 }
 
 // List returns the user repository list.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories?%s", encodeListRoleOptions(opts))
+	// If a specific URL is provided (pagination), use it directly
 	if opts.URL != "" {
-		path = opts.URL
+		out := new(repositories)
+		res, err := s.client.do(ctx, "GET", opts.URL, nil, &out)
+		if err != nil {
+			return nil, res, err
+		}
+		copyPagination(out.pagination, res)
+		return convertRepositoryList(out), res, err
 	}
-	out := new(repositories)
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	copyPagination(out.pagination, res)
-	return convertRepositoryList(out), res, err
+
+	// Use helper to fetch repos from all workspaces
+	// (replaces deprecated /2.0/repositories endpoint)
+	return s.client.fetchReposFromAllWorkspaces(ctx, encodeListRoleOptions(opts))
 }
 
 // ListV2 returns the user repository list based on the searchTerm passed.
 func (s *repositoryService) ListV2(ctx context.Context, opts scm.RepoListOptions) ([]*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories?%s", encodeRepoListOptions(opts))
+	// If a specific URL is provided (pagination), use it directly
 	if opts.ListOptions.URL != "" {
-		path = opts.ListOptions.URL
+		out := new(repositories)
+		res, err := s.client.do(ctx, "GET", opts.ListOptions.URL, nil, &out)
+		if err != nil {
+			return nil, res, err
+		}
+		copyPagination(out.pagination, res)
+		return convertRepositoryList(out), res, err
 	}
-	out := new(repositories)
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	copyPagination(out.pagination, res)
-	return convertRepositoryList(out), res, err
+
+	// Use helper to fetch repos from all workspaces
+	// (replaces deprecated /2.0/repositories endpoint)
+	return s.client.fetchReposFromAllWorkspaces(ctx, encodeRepoListOptions(opts))
 }
 
 func (s *repositoryService) ListNamespace(ctx context.Context, namespace string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
@@ -271,6 +323,36 @@ func convertPerms(from *perms) *scm.Perm {
 		return to
 	}
 	switch from.Values[0].Permissions {
+	case "admin":
+		to.Pull = true
+		to.Push = true
+		to.Admin = true
+	case "write":
+		to.Pull = true
+		to.Push = true
+	default:
+		to.Pull = true
+	}
+	return to
+}
+
+// workspaceRepoPerms represents the response from
+// GET /2.0/workspaces/{workspace}/permissions/repositories/{repo_slug}
+type workspaceRepoPerms struct {
+	Values []*workspaceRepoPerm `json:"values"`
+}
+
+type workspaceRepoPerm struct {
+	Permission string `json:"permission"` // "admin", "write", "read"
+}
+
+func convertWorkspaceRepoPerms(from *workspaceRepoPerms) *scm.Perm {
+	to := new(scm.Perm)
+	if len(from.Values) == 0 {
+		return to
+	}
+	// Find the current user's permission
+	switch from.Values[0].Permission {
 	case "admin":
 		to.Pull = true
 		to.Push = true

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -87,7 +87,7 @@ func TestRepositoryPerms(t *testing.T) {
 	}
 }
 
-func TestRepositoryList(t *testing.T) {
+func TestRepositoryListWorkspaceAggregation(t *testing.T) {
 	defer gock.Off()
 
 	// First, mock the user/workspaces endpoint to get workspace list
@@ -112,7 +112,42 @@ func TestRepositoryList(t *testing.T) {
 	}
 
 	want := []*scm.Repository{}
-	raw, _ := ioutil.ReadFile("testdata/repos.json.golden")
+	raw, _ := ioutil.ReadFile("testdata/repos_single.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestRepositoryListURLPassthrough(t *testing.T) {
+	defer gock.Off()
+
+	// Test URL pass-through for pagination - when opts.URL is set,
+	// it should use the URL directly without workspace aggregation
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian").
+		MatchParam("pagelen", "1").
+		MatchParam("page", "2").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repos.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	// Simulate pagination by passing URL directly
+	opts := scm.ListOptions{
+		URL: "https://api.bitbucket.org/2.0/repositories/atlassian?pagelen=1&page=2",
+	}
+
+	got, _, err := client.Repositories.List(context.Background(), opts)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := []*scm.Repository{}
+	raw, _ := ioutil.ReadFile("testdata/repos_single.json.golden")
 	json.Unmarshal(raw, &want)
 
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -64,12 +64,12 @@ func TestRepositoryFind_NotFound(t *testing.T) {
 func TestRepositoryPerms(t *testing.T) {
 	defer gock.Off()
 
+	// Uses new workspace-scoped permissions endpoint
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/user/permissions/repositories").
-		// MatchParam("repository.full_name", `"atlassian/stash-example-plugin"`).
+		Get("/2.0/workspaces/atlassian/permissions/repositories/stash-example-plugin").
 		Reply(200).
 		Type("application/json").
-		File("testdata/perms.json")
+		File("testdata/workspace_repo_perms.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Repositories.FindPerms(context.Background(), "atlassian/stash-example-plugin")
@@ -90,40 +90,25 @@ func TestRepositoryPerms(t *testing.T) {
 func TestRepositoryList(t *testing.T) {
 	defer gock.Off()
 
+	// First, mock the user/workspaces endpoint to get workspace list
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
-		MatchParam("after", "PLACEHOLDER").
-		MatchParam("pagelen", "1").
-		MatchParam("role", "member").
+		Get("/2.0/user/workspaces").
 		Reply(200).
 		Type("application/json").
-		File("testdata/repos-2.json")
+		File("testdata/user_workspaces.json")
 
+	// Then mock the repositories endpoint for that workspace
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
-		MatchParam("pagelen", "1").
-		MatchParam("role", "member").
+		Get("/2.0/repositories/atlassian").
 		Reply(200).
 		Type("application/json").
 		File("testdata/repos.json")
 
-	got := []*scm.Repository{}
-	opts := scm.ListOptions{Size: 1}
 	client, _ := New("https://api.bitbucket.org")
-
-	for {
-		repos, res, err := client.Repositories.List(context.Background(), opts)
-		if err != nil {
-			t.Error(err)
-		}
-		got = append(got, repos...)
-
-		opts.Page = res.Page.Next
-		opts.URL = res.Page.NextURL
-
-		if opts.Page == 0 && opts.URL == "" {
-			break
-		}
+	got, _, err := client.Repositories.List(context.Background(), scm.ListOptions{Size: 1})
+	if err != nil {
+		t.Error(err)
+		return
 	}
 
 	want := []*scm.Repository{}
@@ -139,23 +124,28 @@ func TestRepositoryList(t *testing.T) {
 func TestRepositoryListV2(t *testing.T) {
 	defer gock.Off()
 
+	// First, mock the user/workspaces endpoint to get workspace list
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
-		MatchParam("q", "name~\\\"plugin1\\\"").
-		MatchParam("role", "member").
+		Get("/2.0/user/workspaces").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_workspaces.json")
+
+	// Then mock the repositories endpoint for that workspace with search filter
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian").
 		Reply(200).
 		Type("application/json").
 		File("testdata/repos_filter.json")
 
-	got := []*scm.Repository{}
 	opts := scm.RepoListOptions{RepoSearchTerm: scm.RepoSearchTerm{RepoName: "plugin1"}}
 	client, _ := New("https://api.bitbucket.org")
 
-	repos, _, err := client.Repositories.ListV2(context.Background(), opts)
+	got, _, err := client.Repositories.ListV2(context.Background(), opts)
 	if err != nil {
 		t.Error(err)
+		return
 	}
-	got = append(got, repos...)
 
 	want := []*scm.Repository{}
 	raw, _ := ioutil.ReadFile("testdata/repos_filter.json.golden")

--- a/scm/driver/bitbucket/testdata/repos_single.json.golden
+++ b/scm/driver/bitbucket/testdata/repos_single.json.golden
@@ -1,0 +1,15 @@
+[
+    {
+        "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+        "Namespace": "atlassian",
+        "Name": "stash-example-plugin",
+        "Perm": null,
+        "Branch": "master",
+        "Private": true,
+        "Clone": "https://bitbucket.org/atlassian/stash-example-plugin.git",
+        "CloneSSH": "git@bitbucket.org:atlassian/stash-example-plugin.git",
+        "Link": "https://bitbucket.org/atlassian/stash-example-plugin",
+        "Created": "2013-04-15T03:05:05.595458Z",
+        "Updated": "2018-04-01T16:36:35.970175Z"
+    }
+]

--- a/scm/driver/bitbucket/testdata/user_workspaces.json
+++ b/scm/driver/bitbucket/testdata/user_workspaces.json
@@ -1,0 +1,27 @@
+{
+  "pagelen": 30,
+  "page": 1,
+  "size": 1,
+  "values": [
+    {
+      "type": "workspace_access",
+      "administrator": true,
+      "workspace": {
+        "type": "workspace_base",
+        "uuid": "{d5bb8c49-f033-4498-910e-7e4b546b04ee}",
+        "slug": "atlassian",
+        "links": {
+          "avatar": {
+            "href": "https://bitbucket.org/workspaces/atlassian/avatar/"
+          },
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/workspaces/atlassian"
+          },
+          "html": {
+            "href": "https://bitbucket.org/atlassian/"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scm/driver/bitbucket/testdata/user_workspaces.json.golden
+++ b/scm/driver/bitbucket/testdata/user_workspaces.json.golden
@@ -1,0 +1,6 @@
+[
+    {
+        "Name": "atlassian",
+        "Avatar": "https://bitbucket.org/workspaces/atlassian/avatar/"
+    }
+]

--- a/scm/driver/bitbucket/testdata/workspace_repo_perms.json
+++ b/scm/driver/bitbucket/testdata/workspace_repo_perms.json
@@ -1,0 +1,28 @@
+{
+  "pagelen": 10,
+  "values": [
+    {
+      "type": "repository_permission",
+      "user": {
+        "username": "johndoe",
+        "display_name": "John Doe",
+        "account_id": "557058:2a6349dc-4346-4805-bd84-3abdd0812d17",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/johndoe"
+          },
+          "html": {
+            "href": "https://bitbucket.org/johndoe/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/johndoe/avatar/32/"
+          }
+        },
+        "type": "user",
+        "uuid": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}"
+      },
+      "permission": "admin"
+    }
+  ],
+  "page": 1
+}

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -5,6 +5,8 @@
 package bitbucket
 
 import (
+	"context"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -148,4 +150,119 @@ func copyPagination(from pagination, to *scm.Response) error {
 	to.Page.First = 1
 	to.Page.Next, _ = strconv.Atoi(page)
 	return nil
+}
+
+// extractWorkspaceFromURL attempts to extract workspace from the client's BaseURL path.
+// Expected URL patterns:
+// - https://api.bitbucket.org/2.0/repositories/{workspace}/
+// - https://api.bitbucket.org/{workspace}/
+// Returns empty string if no workspace found in URL.
+func (c *wrapper) extractWorkspaceFromURL() string {
+	path := strings.Trim(c.BaseURL.Path, "/")
+	if path == "" {
+		return ""
+	}
+
+	parts := strings.Split(path, "/")
+
+	// Look for "repositories/{workspace}" pattern
+	for i, part := range parts {
+		if part == "repositories" && i+1 < len(parts) && parts[i+1] != "" {
+			return parts[i+1]
+		}
+	}
+
+	// If path has segments and last one is not "2.0", it might be workspace
+	if len(parts) > 0 {
+		last := parts[len(parts)-1]
+		if last != "" && last != "2.0" {
+			return last
+		}
+	}
+
+	return ""
+}
+
+// workspaceAccess represents a single workspace access entry from /2.0/user/workspaces
+type workspaceAccess struct {
+	Type          string     `json:"type"`
+	Administrator bool       `json:"administrator"`
+	Workspace     *workspace `json:"workspace"`
+}
+
+// workspace represents the nested workspace object in /2.0/user/workspaces response
+type workspace struct {
+	Type  string `json:"type"`
+	UUID  string `json:"uuid"`
+	Slug  string `json:"slug"`
+	Links struct {
+		Avatar link `json:"avatar"`
+		Self   link `json:"self"`
+		HTML   link `json:"html"`
+	} `json:"links"`
+}
+
+// workspaceAccessList represents the paginated response from /2.0/user/workspaces
+type workspaceAccessList struct {
+	pagination
+	Values []*workspaceAccess `json:"values"`
+}
+
+// fetchAllWorkspaces fetches all workspaces for the authenticated user
+// using the /2.0/user/workspaces endpoint.
+func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
+	var workspaceSlugs []string
+	page := 1
+
+	for {
+		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pagelen=100", page)
+		out := new(workspaceAccessList)
+		_, err := c.do(ctx, "GET", path, nil, out)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, wa := range out.Values {
+			if wa.Workspace != nil && wa.Workspace.Slug != "" {
+				workspaceSlugs = append(workspaceSlugs, wa.Workspace.Slug)
+			}
+		}
+
+		// Check if there are more pages
+		if out.Next == "" {
+			break
+		}
+		page++
+	}
+
+	return workspaceSlugs, nil
+}
+
+// fetchReposFromAllWorkspaces fetches repositories from all user workspaces.
+// This is used by List() and ListV2() to aggregate repositories across all
+// workspaces after the /2.0/repositories deprecation.
+func (c *wrapper) fetchReposFromAllWorkspaces(ctx context.Context, queryParams string) ([]*scm.Repository, *scm.Response, error) {
+	// Step 1: Fetch all workspaces
+	workspaces, err := c.fetchAllWorkspaces(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Step 2: Aggregate repositories from all workspaces
+	var allRepos []*scm.Repository
+	var lastRes *scm.Response
+
+	for _, ws := range workspaces {
+		path := fmt.Sprintf("2.0/repositories/%s?%s", ws, queryParams)
+		out := new(repositories)
+		res, err := c.do(ctx, "GET", path, nil, &out)
+		if err != nil {
+			// Continue to next workspace on error (user may not have access)
+			continue
+		}
+		allRepos = append(allRepos, convertRepositoryList(out)...)
+		lastRes = res
+	}
+
+	return allRepos, lastRes, nil
 }

--- a/scm/driver/bitbucket/util_test.go
+++ b/scm/driver/bitbucket/util_test.go
@@ -5,6 +5,7 @@
 package bitbucket
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/drone/go-scm/scm"
@@ -99,5 +100,54 @@ func Test_copyPagination(t *testing.T) {
 		if got, want := res.Page.Next, test.want.Next; got != want {
 			t.Errorf("Want Next page %d, got %d", want, got)
 		}
+	}
+}
+
+func Test_extractWorkspaceFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "default api url",
+			url:  "https://api.bitbucket.org/",
+			want: "",
+		},
+		{
+			name: "api url without trailing slash",
+			url:  "https://api.bitbucket.org",
+			want: "",
+		},
+		{
+			name: "workspace in repositories path",
+			url:  "https://api.bitbucket.org/2.0/repositories/my-workspace/",
+			want: "my-workspace",
+		},
+		{
+			name: "workspace in repositories path without trailing slash",
+			url:  "https://api.bitbucket.org/2.0/repositories/my-workspace",
+			want: "my-workspace",
+		},
+		{
+			name: "workspace as last path segment",
+			url:  "https://api.bitbucket.org/my-workspace/",
+			want: "my-workspace",
+		},
+		{
+			name: "only 2.0 in path",
+			url:  "https://api.bitbucket.org/2.0/",
+			want: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, _ := url.Parse(test.url)
+			client := &wrapper{&scm.Client{BaseURL: parsed}}
+			got := client.extractWorkspaceFromURL()
+			if got != test.want {
+				t.Errorf("Want workspace %q, got %q", test.want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This pull request modernizes and improves Bitbucket API integration by updating deprecated endpoints, enhancing repository and workspace listing, and improving permission handling. The main changes include switching to the new `/2.0/user/workspaces` endpoint, aggregating repositories across all user workspaces, updating the way repository permissions are fetched, and refactoring related tests and utilities.

**Bitbucket API endpoint migration and workspace support:**

* Updated organization listing to use the new `/2.0/user/workspaces` endpoint instead of the deprecated `/2.0/workspaces`, with new types and conversion logic to support the updated response format. [[1]](diffhunk://#diff-46c27d5851eb2b1a6c03aad14c360ab2d17cc9d2b590c5c05fa7cccc89639040L30-R61) [[2]](diffhunk://#diff-d11bfd98e6b72330250844f3d1b2a7b94e88a4245870e9eb8bfcb58e2bef3918R154-R268)
* Added helper functions and types (`workspaceAccess`, `workspace`, `workspaceAccessList`) for fetching and parsing all user workspaces, and updated related tests and golden files. [[1]](diffhunk://#diff-d11bfd98e6b72330250844f3d1b2a7b94e88a4245870e9eb8bfcb58e2bef3918R154-R268) [[2]](diffhunk://#diff-e104a4653a6d79376b3130d623a2d1833736e714a994b0a03e6a5ab309ff9cd9R47-R54) [[3]](diffhunk://#diff-e104a4653a6d79376b3130d623a2d1833736e714a994b0a03e6a5ab309ff9cd9L62-R63) [[4]](diffhunk://#diff-147c0127e70c40bf57291a572c87b50454c66db6828678afdb113f578b1ba0a5R1-R27) [[5]](diffhunk://#diff-5cb5d17cdeabc18aaa63324f3eabcfea99c3b8c219dba107d8de597fbd2cd3cbR1-R6)

**Repository listing and aggregation:**

* Replaced the deprecated `/2.0/repositories` endpoint for listing repositories with logic to aggregate repositories from all user workspaces using the new workspaces API, including a utility function to fetch repositories across all workspaces. [[1]](diffhunk://#diff-7051591bec36f94815911a1e5609299d6a33f3aae0641e74332f077f1ed0b5d4L90-R171) [[2]](diffhunk://#diff-d11bfd98e6b72330250844f3d1b2a7b94e88a4245870e9eb8bfcb58e2bef3918R154-R268)
* Updated repository listing tests to mock the new endpoints and aggregate repository results accordingly. [[1]](diffhunk://#diff-909fe2e297a3999082c83752dbbbc1a3d7a75cc045cdffc6e0233fe5d55f0161R93-R111) [[2]](diffhunk://#diff-909fe2e297a3999082c83752dbbbc1a3d7a75cc045cdffc6e0233fe5d55f0161R127-L158) [[3]](diffhunk://#diff-0129571caa21463e16343f42d68973532616ac6561aea1d7478b58179175947dL2-L14)

**Repository permissions:**

* Changed repository permission fetching to use the new workspace-scoped endpoint `/2.0/workspaces/{workspace}/permissions/repositories/{repo_slug}`, with logic to extract the workspace from the URL or repository string, and fallback to iterating all workspaces if needed. Added new types and conversion logic for the updated permissions response. [[1]](diffhunk://#diff-7051591bec36f94815911a1e5609299d6a33f3aae0641e74332f077f1ed0b5d4L90-R171) [[2]](diffhunk://#diff-7051591bec36f94815911a1e5609299d6a33f3aae0641e74332f077f1ed0b5d4R339-R368) [[3]](diffhunk://#diff-909fe2e297a3999082c83752dbbbc1a3d7a75cc045cdffc6e0233fe5d55f0161R67-R72) [[4]](diffhunk://#diff-a00d8f1ffd141eb7d474fa098a4352ed1b7b8855b19407aae9eff19f8c2cf2a4R1-R28)

**Utility and test improvements:**

* Added the `extractWorkspaceFromURL` utility to determine the workspace from the API base URL, with comprehensive unit tests for different URL patterns. [[1]](diffhunk://#diff-d11bfd98e6b72330250844f3d1b2a7b94e88a4245870e9eb8bfcb58e2bef3918R154-R268) [[2]](diffhunk://#diff-fa7bba8ee9058a56553125062220c943470b52ee329755252c0491e1ff3fd284R105-R153)
* Refactored imports and minor code cleanup for maintainability. [[1]](diffhunk://#diff-7051591bec36f94815911a1e5609299d6a33f3aae0641e74332f077f1ed0b5d4R11) [[2]](diffhunk://#diff-d11bfd98e6b72330250844f3d1b2a7b94e88a4245870e9eb8bfcb58e2bef3918R8-R9) [[3]](diffhunk://#diff-fa7bba8ee9058a56553125062220c943470b52ee329755252c0491e1ff3fd284R8)