### PR TITLE
feat: [PIPE-32185]: handle deprecated cross-workspace API endpoints

### DIFF
--- a/scm/driver/bitbucket/content_test.go
+++ b/scm/driver/bitbucket/content_test.go
@@ -244,7 +244,7 @@ func TestContentList(t *testing.T) {
 func TestContentListWithUrlInput(t *testing.T) {
 	defer gock.Off()
 
-	mockNextPageUri := "https://api.bitbucket.org/2.0/repositories/atlassian/atlaskit/src/master/packages/activity?pageLen=3&page=RPfL"
+	mockNextPageUri := "https://api.bitbucket.org/2.0/repositories/atlassian/atlaskit/src/master/packages/activity?pagelen=3&page=RPfL"
 
 	gock.New(mockNextPageUri).
 		Reply(200).

--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -11,6 +11,10 @@ import (
 	"github.com/drone/go-scm/scm"
 )
 
+const (
+	avatarURLTemplate = "https://bitbucket.org/account/%s/avatar/32/"
+)
+
 type organizationService struct {
 	client *wrapper
 }
@@ -36,9 +40,9 @@ func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([
 
 func convertWorkspaceAccessList(from *workspaceAccessList) []*scm.Organization {
 	to := []*scm.Organization{}
-	for _, values := range from.Values {
-		if values.Workspace != nil {
-			to = append(to, convertWorkspace(values.Workspace))
+	for _, value := range from.Values {
+		if value.Workspace != nil {
+			to = append(to, convertWorkspace(value.Workspace))
 		}
 	}
 	return to
@@ -51,7 +55,7 @@ type organization struct {
 func convertOrganization(from *organization) *scm.Organization {
 	return &scm.Organization{
 		Name:   from.Login,
-		Avatar: fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32/", from.Login),
+		Avatar: fmt.Sprintf(avatarURLTemplate, from.Login),
 	}
 }
 
@@ -60,7 +64,7 @@ func convertWorkspace(workspace *workspace) *scm.Organization {
 	if workspace.Links.Avatar.Href != "" {
 		avatar = workspace.Links.Avatar.Href
 	} else {
-		avatar = fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32", workspace.Slug)
+		avatar = fmt.Sprintf(avatarURLTemplate, workspace.Slug)
 	}
 	return &scm.Organization{
 		Name:   workspace.Slug,

--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -27,24 +27,21 @@ func (s *organizationService) FindMembership(ctx context.Context, name, username
 }
 
 func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/workspaces?%s", encodeListRoleOptions(opts))
-	out := new(organizationList)
+	path := fmt.Sprintf("2.0/user/workspaces?%s", encodeListRoleOptions(opts))
+	out := new(workspaceAccessList)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	copyPagination(out.pagination, res)
-	return convertOrganizationList(out), res, err
+	return convertWorkspaceAccessList(out), res, err
 }
 
-func convertOrganizationList(from *organizationList) []*scm.Organization {
+func convertWorkspaceAccessList(from *workspaceAccessList) []*scm.Organization {
 	to := []*scm.Organization{}
-	for _, v := range from.Values {
-		to = append(to, convertOrganization(v))
+	for _, values := range from.Values {
+		if values.Workspace != nil {
+			to = append(to, convertWorkspace(values.Workspace))
+		}
 	}
 	return to
-}
-
-type organizationList struct {
-	pagination
-	Values []*organization `json:"values"`
 }
 
 type organization struct {
@@ -55,5 +52,18 @@ func convertOrganization(from *organization) *scm.Organization {
 	return &scm.Organization{
 		Name:   from.Login,
 		Avatar: fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32/", from.Login),
+	}
+}
+
+func convertWorkspace(workspace *workspace) *scm.Organization {
+	avatar := ""
+	if workspace.Links.Avatar.Href != "" {
+		avatar = workspace.Links.Avatar.Href
+	} else {
+		avatar = fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32", workspace.Slug)
+	}
+	return &scm.Organization{
+		Name:   workspace.Slug,
+		Avatar: avatar,
 	}
 }

--- a/scm/driver/bitbucket/org_test.go
+++ b/scm/driver/bitbucket/org_test.go
@@ -45,12 +45,13 @@ func TestOrganizationList(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces").
+		Get("/2.0/user/workspaces").
 		MatchParam("pagelen", "30").
 		MatchParam("page", "1").
+		MatchParam("role", "member").
 		Reply(200).
 		Type("application/json").
-		File("testdata/teams.json")
+		File("testdata/user_workspaces.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Organizations.List(context.Background(), scm.ListOptions{Size: 30, Page: 1})
@@ -59,11 +60,125 @@ func TestOrganizationList(t *testing.T) {
 	}
 
 	want := []*scm.Organization{}
-	raw, _ := ioutil.ReadFile("testdata/teams.json.golden")
+	raw, _ := ioutil.ReadFile("testdata/user_workspaces.json.golden")
 	json.Unmarshal(raw, &want)
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
+	}
+}
+
+func TestConvertWorkspace(t *testing.T) {
+	tests := []struct {
+		name      string
+		workspace *workspace
+		want      *scm.Organization
+	}{
+		{
+			name: "workspace with avatar link",
+			workspace: &workspace{
+				Slug: "my-workspace",
+				Links: struct {
+					Avatar link `json:"avatar"`
+				}{
+					Avatar: link{Href: "https://bitbucket.org/account/my-workspace/avatar/32/"},
+				},
+			},
+			want: &scm.Organization{
+				Name:   "my-workspace",
+				Avatar: "https://bitbucket.org/account/my-workspace/avatar/32/",
+			},
+		},
+		{
+			name: "workspace without avatar link",
+			workspace: &workspace{
+				Slug: "test-workspace",
+				Links: struct {
+					Avatar link `json:"avatar"`
+				}{
+					Avatar: link{Href: ""},
+				},
+			},
+			want: &scm.Organization{
+				Name:   "test-workspace",
+				Avatar: "https://bitbucket.org/account/test-workspace/avatar/32",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertWorkspace(tt.workspace)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("convertWorkspace() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertWorkspaceAccessList(t *testing.T) {
+	tests := []struct {
+		name string
+		from *workspaceAccessList
+		want []*scm.Organization
+	}{
+		{
+			name: "valid workspaces",
+			from: &workspaceAccessList{
+				Values: []*workspaceAccess{
+					{
+						Workspace: &workspace{
+							Slug: "workspace1",
+							Links: struct {
+								Avatar link `json:"avatar"`
+							}{
+								Avatar: link{Href: "https://bitbucket.org/account/workspace1/avatar/32/"},
+							},
+						},
+					},
+					{
+						Workspace: &workspace{
+							Slug: "workspace2",
+							Links: struct {
+								Avatar link `json:"avatar"`
+							}{
+								Avatar: link{Href: ""},
+							},
+						},
+					},
+				},
+			},
+			want: []*scm.Organization{
+				{
+					Name:   "workspace1",
+					Avatar: "https://bitbucket.org/account/workspace1/avatar/32/",
+				},
+				{
+					Name:   "workspace2",
+					Avatar: "https://bitbucket.org/account/workspace2/avatar/32",
+				},
+			},
+		},
+		{
+			name: "nil workspace",
+			from: &workspaceAccessList{
+				Values: []*workspaceAccess{
+					{
+						Workspace: nil,
+					},
+				},
+			},
+			want: []*scm.Organization{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertWorkspaceAccessList(tt.from)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("convertWorkspaceAccessList() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/scm/driver/bitbucket/org_test.go
+++ b/scm/driver/bitbucket/org_test.go
@@ -102,7 +102,7 @@ func TestConvertWorkspace(t *testing.T) {
 			},
 			want: &scm.Organization{
 				Name:   "test-workspace",
-				Avatar: "https://bitbucket.org/account/test-workspace/avatar/32",
+				Avatar: "https://bitbucket.org/account/test-workspace/avatar/32/",
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func TestConvertWorkspaceAccessList(t *testing.T) {
 				},
 				{
 					Name:   "workspace2",
-					Avatar: "https://bitbucket.org/account/workspace2/avatar/32",
+					Avatar: "https://bitbucket.org/account/workspace2/avatar/32/",
 				},
 			},
 		},

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -134,34 +134,26 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	return nil, nil, fmt.Errorf("repository %s not found in any workspace", repo)
 }
 
-// List returns the user repository list.
+// List returns the user repository list using workspace-aware pagination.
+// Fetches repos across all workspaces (sorted by slug) and fills the page
+// by stitching results from multiple workspaces when needed.
+// Defaults to page 1 if not specified.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	if opts.URL != "" {
-		repoStruct := new(repositories)
-		response, err := s.client.do(ctx, "GET", opts.URL, nil, &repoStruct)
-		if err != nil {
-			return nil, response, err
-		}
-		copyPagination(repoStruct.pagination, response)
-		return convertRepositoryList(repoStruct), response, err
+	if opts.Page == 0 {
+		opts.Page = 1
 	}
-
-	return s.client.fetchReposFromAllWorkspaces(ctx, encodeListRoleOptions(opts))
+	return s.client.fetchReposWithPagination(ctx, encodeListRoleOptions(opts), opts.Page, opts.Size)
 }
 
 // ListV2 returns the user repository list based on the searchTerm passed.
+// Uses the same workspace-aware pagination as List, with an additional
+// search filter applied to each workspace query.
+// Defaults to page 1 if not specified.
 func (s *repositoryService) ListV2(ctx context.Context, opts scm.RepoListOptions) ([]*scm.Repository, *scm.Response, error) {
-	if opts.ListOptions.URL != "" {
-		repoStruct := new(repositories)
-		response, err := s.client.do(ctx, "GET", opts.ListOptions.URL, nil, &repoStruct)
-		if err != nil {
-			return nil, response, err
-		}
-		copyPagination(repoStruct.pagination, response)
-		return convertRepositoryList(repoStruct), response, err
+	if opts.ListOptions.Page == 0 {
+		opts.ListOptions.Page = 1
 	}
-
-	return s.client.fetchReposFromAllWorkspaces(ctx, encodeRepoListOptions(opts))
+	return s.client.fetchReposWithPagination(ctx, encodeRepoListOptions(opts), opts.ListOptions.Page, opts.ListOptions.Size)
 }
 
 func (s *repositoryService) ListNamespace(ctx context.Context, namespace string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -88,56 +88,71 @@ func (s *repositoryService) FindHook(ctx context.Context, repo string, id string
 
 // FindPerms returns the repository permissions.
 func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Perm, *scm.Response, error) {
-	// Try to extract workspace from the client URL
-	workspace := s.client.extractWorkspaceFromURL()
+	// First, try to fetch using the repo identifier provided
+	perm, res, err := s.findPermsWithIdentifier(ctx, repo)
+	if err == nil {
+		return perm, res, nil
+	}
 
-	// If workspace is available, use it to fetch permissions
+	// If that fails and repo isn't in "workspace/repo" format,
+	// search all workspaces as a fallback
+	if !strings.Contains(repo, "/") {
+		return s.findPermsAcrossWorkspaces(ctx, repo)
+	}
+
+	// Repo is in "workspace/repo" format and fetch failed
+	return nil, res, err
+}
+
+// findPermsWithIdentifier attempts to fetch permissions using either the
+// extracted workspace from the client URL or the workspace in "workspace/repo" format.
+func (s *repositoryService) findPermsWithIdentifier(ctx context.Context, repo string) (*scm.Perm, *scm.Response, error) {
+	workspace := s.client.extractWorkspaceFromURL()
+	repoSlug := repo
+
+	// If workspace is in the repo identifier (workspace/repo format), use it
+	if strings.Contains(repo, "/") {
+		workspace, repoSlug = scm.Split(repo)
+	}
+
+	// If we have a workspace (either from URL or repo identifier), fetch permissions
 	if workspace != "" {
-		repoSlug := repo
-		// Handle "workspace/repo" format by extracting just the repo slug
-		if strings.Contains(repo, "/") {
-			_, repoSlug = scm.Split(repo)
-		}
 		return s.fetchRepoPerms(ctx, workspace, repoSlug)
 	}
 
-	// If repo is in "workspace/repo" format, split and use both parts
-	if strings.Contains(repo, "/") {
-		ws, repoSlug := scm.Split(repo)
-		return s.fetchRepoPerms(ctx, ws, repoSlug)
-	}
+	// No workspace available
+	return nil, nil, fmt.Errorf("unable to determine workspace for repository %s", repo)
+}
 
-	// Fallback: fetch all workspaces and search for the repository
+// findPermsAcrossWorkspaces searches all user workspaces for the repository
+// and returns permissions if the user has access.
+func (s *repositoryService) findPermsAcrossWorkspaces(ctx context.Context, repoSlug string) (*scm.Perm, *scm.Response, error) {
 	workspaces, err := s.client.fetchAllWorkspaces(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Iterate through workspaces to find the repository with permissions
-	for _, ws := range workspaces {
-		perm, res, err := s.fetchRepoPerms(ctx, ws, repo)
+	for _, workspace := range workspaces {
+		perm, res, err := s.fetchRepoPerms(ctx, workspace, repoSlug)
 		if err != nil {
-			// If it's a 404, the repo doesn't exist in this workspace - continue to next
+			// If it's a 404, the repo doesn't exist in this workspace
 			if res != nil && res.Status == 404 {
 				continue
 			}
 			// For other errors (network, auth, etc.), return immediately
 			return nil, res, err
 		}
+
 		// Return permissions if user has any access to the repository
 		if perm.Pull || perm.Push || perm.Admin {
 			return perm, res, nil
 		}
 	}
 
-	// Repository not found in any workspace
-	return nil, nil, fmt.Errorf("repository %s not found in any workspace", repo)
+	return nil, nil, fmt.Errorf("repository %s not found in any workspace", repoSlug)
 }
 
 // List returns the user repository list using workspace-aware pagination.
-// Fetches repos across all workspaces (sorted by slug) and fills the page
-// by stitching results from multiple workspaces when needed.
-// Defaults to page 1 if not specified.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	if opts.Page == 0 {
 		opts.Page = 1
@@ -146,9 +161,6 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 }
 
 // ListV2 returns the user repository list based on the searchTerm passed.
-// Uses the same workspace-aware pagination as List, with an additional
-// search filter applied to each workspace query.
-// Defaults to page 1 if not specified.
 func (s *repositoryService) ListV2(ctx context.Context, opts scm.RepoListOptions) ([]*scm.Repository, *scm.Response, error) {
 	if opts.ListOptions.Page == 0 {
 		opts.ListOptions.Page = 1

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -110,13 +110,17 @@ func (s *repositoryService) findPermsWithIdentifier(ctx context.Context, repo st
 	workspace := s.client.extractWorkspaceFromURL()
 	repoSlug := repo
 
-	// If workspace is in the repo identifier (workspace/repo format), use it
-	if strings.Contains(repo, "/") {
-		workspace, repoSlug = scm.Split(repo)
+	// If workspace is available from URL, use it and only extract repo slug
+	if workspace != "" {
+		if strings.Contains(repo, "/") {
+			_, repoSlug = scm.Split(repo)
+		}
+		return s.fetchRepoPerms(ctx, workspace, repoSlug)
 	}
 
-	// If we have a workspace (either from URL or repo identifier), fetch permissions
-	if workspace != "" {
+	// If repo is in "workspace/repo" format, use the workspace from repo identifier
+	if strings.Contains(repo, "/") {
+		workspace, repoSlug = scm.Split(repo)
 		return s.fetchRepoPerms(ctx, workspace, repoSlug)
 	}
 

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -87,34 +88,60 @@ func (s *repositoryService) FindHook(ctx context.Context, repo string, id string
 
 // FindPerms returns the repository permissions.
 func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Perm, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/user/permissions/repositories?q=repository.full_name=%q", repo)
-	out := new(perms)
-	res, err := s.client.do(ctx, "GET", path, nil, out)
-	return convertPerms(out), res, err
+	workspace := s.client.extractWorkspaceFromURL()
+
+	if workspace != "" {
+		return s.fetchRepoPerms(ctx, workspace, repo)
+	}
+
+	if strings.Contains(repo, "/") {
+		ws, repoSlug := scm.Split(repo)
+		return s.fetchRepoPerms(ctx, ws, repoSlug)
+	}
+
+	workspaces, err := s.client.fetchAllWorkspaces(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, ws := range workspaces {
+		perm, res, err := s.fetchRepoPerms(ctx, ws, repo)
+		if err == nil && (perm.Pull || perm.Push || perm.Admin) {
+			return perm, res, nil
+		}
+	}
+
+	return &scm.Perm{}, nil, nil
 }
 
 // List returns the user repository list.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories?%s", encodeListRoleOptions(opts))
 	if opts.URL != "" {
-		path = opts.URL
+		repoStruct := new(repositories)
+		response, err := s.client.do(ctx, "GET", opts.URL, nil, &repoStruct)
+		if err != nil {
+			return nil, response, err
+		}
+		copyPagination(repoStruct.pagination, response)
+		return convertRepositoryList(repoStruct), response, err
 	}
-	out := new(repositories)
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	copyPagination(out.pagination, res)
-	return convertRepositoryList(out), res, err
+
+	return s.client.fetchReposFromAllWorkspaces(ctx, encodeListRoleOptions(opts))
 }
 
 // ListV2 returns the user repository list based on the searchTerm passed.
 func (s *repositoryService) ListV2(ctx context.Context, opts scm.RepoListOptions) ([]*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/repositories?%s", encodeRepoListOptions(opts))
 	if opts.ListOptions.URL != "" {
-		path = opts.ListOptions.URL
+		repoStruct := new(repositories)
+		response, err := s.client.do(ctx, "GET", opts.ListOptions.URL, nil, &repoStruct)
+		if err != nil {
+			return nil, response, err
+		}
+		copyPagination(repoStruct.pagination, response)
+		return convertRepositoryList(repoStruct), response, err
 	}
-	out := new(repositories)
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	copyPagination(out.pagination, res)
-	return convertRepositoryList(out), res, err
+
+	return s.client.fetchReposFromAllWorkspaces(ctx, encodeRepoListOptions(opts))
 }
 
 func (s *repositoryService) ListNamespace(ctx context.Context, namespace string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
@@ -390,4 +417,44 @@ func convertFromState(from scm.State) string {
 	default:
 		return "FAILED"
 	}
+}
+
+// workspaceRepoPerms represents the response from
+// GET /2.0/workspaces/{workspace}/permissions/repositories/{repo_slug}
+type workspaceRepoPerms struct {
+	Values []*workspaceRepoPerm `json:"values"`
+}
+
+type workspaceRepoPerm struct {
+	Permission string `json:"permission"` // "admin", "write", "read"
+}
+
+func convertWorkspaceRepoPerms(from *workspaceRepoPerms) *scm.Perm {
+	to := new(scm.Perm)
+	if len(from.Values) == 0 {
+		return to
+	}
+	switch from.Values[0].Permission {
+	case "admin":
+		to.Pull = true
+		to.Push = true
+		to.Admin = true
+	case "write":
+		to.Pull = true
+		to.Push = true
+	default:
+		to.Pull = true
+	}
+	return to
+}
+
+// fetchRepoPerms fetches repository permissions for a given workspace and repo slug.
+func (s *repositoryService) fetchRepoPerms(ctx context.Context, workspace, repoSlug string) (*scm.Perm, *scm.Response, error) {
+	path := fmt.Sprintf("2.0/workspaces/%s/permissions/repositories/%s", workspace, repoSlug)
+	out := new(workspaceRepoPerms)
+	res, err := s.client.do(ctx, "GET", path, nil, out)
+	if err != nil {
+		return nil, res, err
+	}
+	return convertWorkspaceRepoPerms(out), res, nil
 }

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -117,6 +117,11 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	for _, ws := range workspaces {
 		perm, res, err := s.fetchRepoPerms(ctx, ws, repo)
 		if err != nil {
+			// If it's a 404, the repo doesn't exist in this workspace - continue to next
+			if res != nil && res.Status == 404 {
+				continue
+			}
+			// For other errors (network, auth, etc.), return immediately
 			return nil, res, err
 		}
 		// Return permissions if user has any access to the repository
@@ -125,8 +130,8 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 		}
 	}
 
-	// Repository not found or no permissions
-	return &scm.Perm{}, nil, nil
+	// Repository not found in any workspace
+	return nil, nil, fmt.Errorf("repository %s not found in any workspace", repo)
 }
 
 // List returns the user repository list.

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -91,7 +91,11 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	workspace := s.client.extractWorkspaceFromURL()
 
 	if workspace != "" {
-		return s.fetchRepoPerms(ctx, workspace, repo)
+		repoSlug := repo
+		if strings.Contains(repo, "/") {
+			_, repoSlug = scm.Split(repo)
+		}
+		return s.fetchRepoPerms(ctx, workspace, repoSlug)
 	}
 
 	if strings.Contains(repo, "/") {

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -158,6 +158,16 @@ func (s *repositoryService) findPermsAcrossWorkspaces(ctx context.Context, repoS
 
 // List returns the user repository list using workspace-aware pagination.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+	if opts.URL != "" {
+		out := new(repositories)
+		res, err := s.client.do(ctx, "GET", opts.URL, nil, &out)
+		if err != nil {
+			return nil, res, err
+		}
+		copyPagination(out.pagination, res)
+		return convertRepositoryList(out), res, err
+	}
+
 	if opts.Page == 0 {
 		opts.Page = 1
 	}
@@ -166,6 +176,16 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 
 // ListV2 returns the user repository list based on the searchTerm passed.
 func (s *repositoryService) ListV2(ctx context.Context, opts scm.RepoListOptions) ([]*scm.Repository, *scm.Response, error) {
+	if opts.ListOptions.URL != "" {
+		out := new(repositories)
+		res, err := s.client.do(ctx, "GET", opts.ListOptions.URL, nil, &out)
+		if err != nil {
+			return nil, res, err
+		}
+		copyPagination(out.pagination, res)
+		return convertRepositoryList(out), res, err
+	}
+
 	if opts.ListOptions.Page == 0 {
 		opts.ListOptions.Page = 1
 	}

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -88,33 +88,44 @@ func (s *repositoryService) FindHook(ctx context.Context, repo string, id string
 
 // FindPerms returns the repository permissions.
 func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Perm, *scm.Response, error) {
+	// Try to extract workspace from the client URL
 	workspace := s.client.extractWorkspaceFromURL()
 
+	// If workspace is available, use it to fetch permissions
 	if workspace != "" {
 		repoSlug := repo
+		// Handle "workspace/repo" format by extracting just the repo slug
 		if strings.Contains(repo, "/") {
 			_, repoSlug = scm.Split(repo)
 		}
 		return s.fetchRepoPerms(ctx, workspace, repoSlug)
 	}
 
+	// If repo is in "workspace/repo" format, split and use both parts
 	if strings.Contains(repo, "/") {
 		ws, repoSlug := scm.Split(repo)
 		return s.fetchRepoPerms(ctx, ws, repoSlug)
 	}
 
+	// Fallback: fetch all workspaces and search for the repository
 	workspaces, err := s.client.fetchAllWorkspaces(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Iterate through workspaces to find the repository with permissions
 	for _, ws := range workspaces {
 		perm, res, err := s.fetchRepoPerms(ctx, ws, repo)
-		if err == nil && (perm.Pull || perm.Push || perm.Admin) {
+		if err != nil {
+			return nil, res, err
+		}
+		// Return permissions if user has any access to the repository
+		if perm.Pull || perm.Push || perm.Admin {
 			return perm, res, nil
 		}
 	}
 
+	// Repository not found or no permissions
 	return &scm.Perm{}, nil, nil
 }
 

--- a/scm/driver/bitbucket/repo_findperms_test.go
+++ b/scm/driver/bitbucket/repo_findperms_test.go
@@ -1,0 +1,313 @@
+// Copyright 2026 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bitbucket
+
+import (
+	"context"
+	"testing"
+
+	"github.com/h2non/gock"
+)
+
+// TestFindPerms_ErrorWhenAllWorkspaces404 tests the case where repo doesn't exist in any workspace
+func TestFindPerms_ErrorWhenAllWorkspaces404(t *testing.T) {
+	defer gock.Off()
+
+	// Mock workspace list
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}, {"workspace": {"slug": "ws2"}}], "next": ""}`)
+
+	// Both workspaces return 404
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws1/permissions/repositories/nonexistent-repo").
+		Reply(404).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Repository not found"}}`)
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws2/permissions/repositories/nonexistent-repo").
+		Reply(404).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Repository not found"}}`)
+
+	client, _ := New("https://api.bitbucket.org")
+	_, _, err := client.Repositories.FindPerms(context.Background(), "nonexistent-repo")
+
+	if err == nil {
+		t.Fatal("Expected error when repository not found in any workspace")
+	}
+
+	if err.Error() != "repository nonexistent-repo not found in any workspace" {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+}
+
+// TestFindPerms_ErrorWhenWorkspaceFetchFails tests error handling when workspace fetch fails
+func TestFindPerms_ErrorWhenWorkspaceFetchFails(t *testing.T) {
+	defer gock.Off()
+
+	// Mock workspace list with error
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(500).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Internal server error"}}`)
+
+	client, _ := New("https://api.bitbucket.org")
+	_, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+
+	if err == nil {
+		t.Fatal("Expected error when workspace fetch fails")
+	}
+}
+
+// TestFindPerms_NoPermissions tests when user has no permissions (empty values array)
+func TestFindPerms_NoPermissionsInAnyWorkspace(t *testing.T) {
+	defer gock.Off()
+
+	// Mock workspace list
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}], "next": ""}`)
+
+	// Workspace returns empty permissions (no access)
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": []}`)
+
+	client, _ := New("https://api.bitbucket.org")
+	_, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+
+	// When user has no permissions, current implementation returns error
+	// because empty permissions don't satisfy the "has any access" check
+	if err == nil {
+		t.Fatal("Expected error when user has no permissions")
+	}
+
+	if err.Error() != "repository test-repo not found in any workspace" {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+}
+
+// TestFindPerms_NetworkErrorInMiddleWorkspace tests partial network failure
+func TestFindPerms_NetworkErrorReturnsImmediately(t *testing.T) {
+	defer gock.Off()
+
+	// Mock workspace list
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}, {"workspace": {"slug": "ws2"}}], "next": ""}`)
+
+	// First workspace returns 500 (not a 404)
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
+		Reply(500).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Internal server error"}}`)
+
+	client, _ := New("https://api.bitbucket.org")
+	_, res, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+
+	// Should return error immediately, not continue to ws2
+	if err == nil {
+		t.Fatal("Expected error for non-404 failure")
+	}
+
+	if res == nil || res.Status != 500 {
+		t.Error("Expected response with 500 status")
+	}
+}
+
+// TestFindPerms_With404ThenSuccess tests that iteration continues on 404
+func TestFindPerms_Continues404ToSuccess(t *testing.T) {
+	defer gock.Off()
+
+	// Mock workspace list
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}, {"workspace": {"slug": "ws2"}}], "next": ""}`)
+
+	// First workspace returns 404 (repo not in this workspace)
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
+		Reply(404).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Not found"}}`)
+
+	// Second workspace has the repo with admin permissions
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws2/permissions/repositories/test-repo").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	perm, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !perm.Admin || !perm.Push || !perm.Pull {
+		t.Error("Expected admin permissions from ws2")
+	}
+}
+
+// TestFindPerms_EmptyWorkspaceList tests when user has no workspaces
+func TestFindPerms_EmptyWorkspaceList(t *testing.T) {
+	defer gock.Off()
+
+	// Mock empty workspace list
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [], "next": ""}`)
+
+	client, _ := New("https://api.bitbucket.org")
+	_, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+
+	if err == nil {
+		t.Fatal("Expected error when no workspaces available")
+	}
+
+	if err.Error() != "repository test-repo not found in any workspace" {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+}
+
+// TestFindPerms_WorkspaceInURLWithFullRepoPath tests that URL workspace is used
+// even when repo has workspace/repo format - it extracts just the repo slug
+func TestFindPerms_WorkspaceInURLExtractionWithSlash(t *testing.T) {
+	defer gock.Off()
+
+	// When workspace is in URL and repo has workspace/repo format,
+	// it should use URL workspace and extract just the repo slug
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/url-workspace/permissions/repositories/actual-repo").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	client, _ := New("https://api.bitbucket.org/repositories/url-workspace")
+	perm, _, err := client.Repositories.FindPerms(context.Background(), "different-workspace/actual-repo")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !perm.Admin {
+		t.Error("Expected admin permissions")
+	}
+
+	// Verify the correct endpoint was called (url-workspace, not different-workspace)
+	if !gock.IsDone() {
+		pending := gock.Pending()
+		if len(pending) > 0 {
+			t.Errorf("Expected all mocks to be called, pending: %v", pending[0].Request().URLStruct)
+		}
+	}
+}
+
+// TestFindPerms_PriorityOfWorkspaceResolution tests that URL workspace takes priority
+func TestFindPerms_URLWorkspaceTakesPriority(t *testing.T) {
+	defer gock.Off()
+
+	// URL workspace should take priority over repo identifier workspace
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/url-workspace/permissions/repositories/repo-slug").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	// Should NOT call identifier-workspace even though repo is "identifier-workspace/repo-slug"
+	client, _ := New("https://api.bitbucket.org/repositories/url-workspace")
+	perm, _, err := client.Repositories.FindPerms(context.Background(), "identifier-workspace/repo-slug")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !perm.Admin {
+		t.Error("Expected admin permissions from url-workspace")
+	}
+
+	// Verify the correct endpoint was called (url-workspace, not identifier-workspace)
+	if !gock.IsDone() {
+		pending := gock.Pending()
+		if len(pending) > 0 {
+			t.Errorf("Expected all mocks to be called, pending: %v", pending[0].Request().URLStruct)
+		}
+	}
+}
+
+// TestFindPerms_MultipleWorkspacesMultiplePages tests pagination in workspace fetching
+func TestFindPerms_WorkspacePagination(t *testing.T) {
+	defer gock.Off()
+
+	// Mock workspace list with multiple pages
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pagelen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}], "next": "https://api.bitbucket.org/2.0/user/workspaces?page=2"}`)
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "2").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "ws2"}}], "next": ""}`)
+
+	// First workspace returns 404
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
+		Reply(404).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Not found"}}`)
+
+	// Second workspace (from page 2) has the repo
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/ws2/permissions/repositories/test-repo").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	perm, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !perm.Admin {
+		t.Error("Expected to find permissions from workspace on page 2")
+	}
+}

--- a/scm/driver/bitbucket/repo_listing_edge_cases_test.go
+++ b/scm/driver/bitbucket/repo_listing_edge_cases_test.go
@@ -1,0 +1,564 @@
+// Copyright 2026 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/drone/go-scm/scm"
+)
+
+// TestList_AllWorkspacesEmpty tests when all workspaces have zero repositories
+func TestList_AllWorkspacesEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+					{"workspace": map[string]string{"slug": "ws2"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		// Both workspaces have 0 repos
+		if r.URL.Path == "/2.0/repositories/ws1" || r.URL.Path == "/2.0/repositories/ws2" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{},
+				"size":   0,
+				"next":   "",
+			})
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	repos, res, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 0 {
+		t.Errorf("Expected 0 repos, got %d", len(repos))
+	}
+
+	if res.Page.Next != 0 {
+		t.Errorf("Expected no next page, got %d", res.Page.Next)
+	}
+}
+
+// TestList_NoWorkspaces tests when user has no workspaces
+func TestList_NoWorkspaces(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{},
+				"next":   "",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	repos, _, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 0 {
+		t.Errorf("Expected 0 repos when no workspaces, got %d", len(repos))
+	}
+}
+
+// TestList_WorkspaceFetchError tests error handling when workspace fetch fails
+func TestList_WorkspaceFetchError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.WriteHeader(500)
+			w.Write([]byte(`{"error": {"message": "Internal server error"}}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	_, _, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err == nil {
+		t.Fatal("Expected error when workspace fetch fails")
+	}
+}
+
+// TestList_SizeZeroDefaultsTo100 tests that size=0 defaults to 100
+func TestList_SizeZeroDefaultsTo100(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 150, "", 150))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Size=0 should default to 100
+	repos, res, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 0})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 100 {
+		t.Errorf("Expected 100 repos (default size), got %d", len(repos))
+	}
+
+	if res.Page.Next != 2 {
+		t.Errorf("Expected next page 2, got %d", res.Page.Next)
+	}
+}
+
+// TestList_VeryLargePageSize tests large page size
+func TestList_LargePageSize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 50, "", 50))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Request 1000 repos but only 50 exist
+	repos, res, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 1000})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 50 {
+		t.Errorf("Expected 50 repos (all available), got %d", len(repos))
+	}
+
+	if res.Page.Next != 0 {
+		t.Errorf("Expected no next page, got %d", res.Page.Next)
+	}
+}
+
+// TestList_ExactPageBoundary tests when workspace repos end exactly at page boundary
+func TestList_ExactPageBoundary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+					{"workspace": map[string]string{"slug": "ws2"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		// ws1 has exactly 100 repos
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 100, "", 100))
+			return
+		}
+
+		// ws2 has 50 repos
+		if r.URL.Path == "/2.0/repositories/ws2" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws2", 0, 50, "", 50))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Page 1: exactly 100 from ws1
+	repos1, res1, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 1 error: %v", err)
+	}
+
+	if len(repos1) != 100 {
+		t.Errorf("Page 1: expected 100 repos, got %d", len(repos1))
+	}
+
+	if res1.Page.Next != 2 {
+		t.Errorf("Page 1: expected next page 2, got %d", res1.Page.Next)
+	}
+
+	// Page 2: 50 from ws2
+	repos2, res2, err := client.Repositories.List(ctx, scm.ListOptions{Page: 2, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 2 error: %v", err)
+	}
+
+	if len(repos2) != 50 {
+		t.Errorf("Page 2: expected 50 repos, got %d", len(repos2))
+	}
+
+	if res2.Page.Next != 0 {
+		t.Errorf("Page 2: expected no next page, got %d", res2.Page.Next)
+	}
+}
+
+// TestList_PartialWorkspaceAccessErrors tests resilience when some workspaces are inaccessible
+func TestList_SkipsInaccessibleWorkspaces(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+					{"workspace": map[string]string{"slug": "ws2"}},
+					{"workspace": map[string]string{"slug": "ws3"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		// ws1: accessible, 50 repos
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 50, "", 50))
+			return
+		}
+
+		// ws2: inaccessible (403)
+		if r.URL.Path == "/2.0/repositories/ws2" {
+			w.WriteHeader(403)
+			w.Write([]byte(`{"error": {"message": "Access denied"}}`))
+			return
+		}
+
+		// ws3: accessible, 30 repos
+		if r.URL.Path == "/2.0/repositories/ws3" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws3", 0, 30, "", 30))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	repos, _, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should get 50 from ws1 + 30 from ws3 = 80 repos (skipping ws2)
+	if len(repos) != 80 {
+		t.Errorf("Expected 80 repos (skipping inaccessible ws2), got %d", len(repos))
+	}
+
+	// Verify repos are from correct workspaces
+	ws1Count := 0
+	ws3Count := 0
+	for _, repo := range repos {
+		if repo.Namespace == "ws1" {
+			ws1Count++
+		} else if repo.Namespace == "ws3" {
+			ws3Count++
+		}
+	}
+
+	if ws1Count != 50 {
+		t.Errorf("Expected 50 repos from ws1, got %d", ws1Count)
+	}
+
+	if ws3Count != 30 {
+		t.Errorf("Expected 30 repos from ws3, got %d", ws3Count)
+	}
+}
+
+// TestList_SingleRepoMultipleWorkspaces tests correct distribution
+func TestList_SmallPageAcrossWorkspaces(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+					{"workspace": map[string]string{"slug": "ws2"}},
+					{"workspace": map[string]string{"slug": "ws3"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 3, "", 3))
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws2" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws2", 0, 3, "", 3))
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws3" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws3", 0, 3, "", 3))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Request page size of 5 (should get 3 from ws1, 2 from ws2)
+	repos, res, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 5})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 5 {
+		t.Errorf("Expected 5 repos, got %d", len(repos))
+	}
+
+	// Should have next page since 9 total > 5
+	if res.Page.Next != 2 {
+		t.Errorf("Expected next page 2, got %d", res.Page.Next)
+	}
+
+	// Verify distribution
+	ws1Count := 0
+	ws2Count := 0
+	for _, repo := range repos {
+		if repo.Namespace == "ws1" {
+			ws1Count++
+		} else if repo.Namespace == "ws2" {
+			ws2Count++
+		}
+	}
+
+	if ws1Count != 3 {
+		t.Errorf("Expected 3 repos from ws1, got %d", ws1Count)
+	}
+
+	if ws2Count != 2 {
+		t.Errorf("Expected 2 repos from ws2, got %d", ws2Count)
+	}
+}
+
+// TestList_OffsetCalculation tests various offset scenarios
+func TestList_OffsetCalculationAcrossPages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			page := r.URL.Query().Get("page")
+			pagelenStr := r.URL.Query().Get("pagelen")
+
+			// Check for count query (pagelen=1)
+			if pagelenStr == "1" {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 1, "", 500))
+				return
+			}
+
+			// Parse pagelen, default to 100 if not specified
+			pagelen := 100
+			if pagelenStr != "" {
+				if n, err := strconv.Atoi(pagelenStr); err == nil && n > 0 {
+					pagelen = n
+				}
+			}
+
+			// Parse page, default to 1
+			pageNum := 1
+			if page != "" {
+				if n, err := strconv.Atoi(page); err == nil && n > 0 {
+					pageNum = n
+				}
+			}
+
+			// Calculate start index based on page and pagelen
+			startIdx := (pageNum - 1) * pagelen
+			count := pagelen
+			if startIdx+count > 500 {
+				count = 500 - startIdx
+			}
+
+			// Calculate next page
+			nextPage := ""
+			if startIdx+count < 500 {
+				nextPage = strconv.Itoa(pageNum + 1)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", startIdx, count, nextPage, 500))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Page 3 with size 50 (offset = (3-1)*50 = 100, should get repos 100-149)
+	repos, res, err := client.Repositories.List(ctx, scm.ListOptions{Page: 3, Size: 50})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 50 {
+		t.Errorf("Expected 50 repos, got %d", len(repos))
+	}
+
+	// Debug: print what we got
+	if len(repos) > 0 {
+		t.Logf("First repo: %s, Last repo: %s", repos[0].Name, repos[len(repos)-1].Name)
+	}
+
+	// Should start from repo-100 (offset 100)
+	if len(repos) > 0 && repos[0].Name != "repo-100" {
+		t.Errorf("Expected first repo to be repo-100, got %s", repos[0].Name)
+	}
+
+	// Should end at repo-149
+	if len(repos) >= 50 && repos[49].Name != "repo-149" {
+		t.Errorf("Expected last repo to be repo-149, got %s", repos[49].Name)
+	}
+
+	if res.Page.Next != 4 {
+		t.Errorf("Expected next page 4, got %d", res.Page.Next)
+	}
+}
+
+// TestListV2_EmptySearchResults tests search with no results
+func TestListV2_NoSearchResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			// Verify search query
+			query := r.URL.Query().Get("q")
+			if query != `name~"nonexistent"` {
+				t.Errorf("Expected search query name~\"nonexistent\", got: %s", query)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{},
+				"size":   0,
+				"next":   "",
+			})
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	repos, res, err := client.Repositories.ListV2(ctx, scm.RepoListOptions{
+		RepoSearchTerm: scm.RepoSearchTerm{RepoName: "nonexistent"},
+		ListOptions:    scm.ListOptions{Page: 1, Size: 100},
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(repos) != 0 {
+		t.Errorf("Expected 0 repos for non-matching search, got %d", len(repos))
+	}
+
+	if res.Page.Next != 0 {
+		t.Errorf("Expected no next page, got %d", res.Page.Next)
+	}
+}
+
+// Note: createMockRepoPageWithSize is defined in repo_workspace_pagination_test.go

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -65,11 +65,10 @@ func TestRepositoryPerms(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/user/permissions/repositories").
-		// MatchParam("repository.full_name", `"atlassian/stash-example-plugin"`).
+		Get("/2.0/workspaces/atlassian/permissions/repositories/stash-example-plugin").
 		Reply(200).
 		Type("application/json").
-		File("testdata/perms.json")
+		File("testdata/workspace_repo_perms.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Repositories.FindPerms(context.Background(), "atlassian/stash-example-plugin")
@@ -78,12 +77,128 @@ func TestRepositoryPerms(t *testing.T) {
 	}
 
 	want := new(scm.Perm)
-	raw, _ := ioutil.ReadFile("testdata/perms.json.golden")
+	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
 	json.Unmarshal(raw, &want)
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
+	}
+}
+
+func TestRepositoryPermsWithWorkspaceInURL(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/my-workspace/permissions/repositories/my-repo").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	client, _ := New("https://api.bitbucket.org/repositories/my-workspace")
+	got, _, err := client.Repositories.FindPerms(context.Background(), "my-repo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := new(scm.Perm)
+	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestRepositoryPermsIterateWorkspaces(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pageLen", "100").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_workspaces.json")
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/my-workspace/permissions/repositories/test-repo").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": []}`)
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/team-workspace/permissions/repositories/test-repo").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	got, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := new(scm.Perm)
+	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestConvertWorkspaceRepoPerms(t *testing.T) {
+	tests := []struct {
+		name string
+		from *workspaceRepoPerms
+		want *scm.Perm
+	}{
+		{
+			name: "admin permission",
+			from: &workspaceRepoPerms{
+				Values: []*workspaceRepoPerm{
+					{Permission: "admin"},
+				},
+			},
+			want: &scm.Perm{Admin: true, Push: true, Pull: true},
+		},
+		{
+			name: "write permission",
+			from: &workspaceRepoPerms{
+				Values: []*workspaceRepoPerm{
+					{Permission: "write"},
+				},
+			},
+			want: &scm.Perm{Admin: false, Push: true, Pull: true},
+		},
+		{
+			name: "read permission",
+			from: &workspaceRepoPerms{
+				Values: []*workspaceRepoPerm{
+					{Permission: "read"},
+				},
+			},
+			want: &scm.Perm{Admin: false, Push: false, Pull: true},
+		},
+		{
+			name: "empty values",
+			from: &workspaceRepoPerms{
+				Values: []*workspaceRepoPerm{},
+			},
+			want: &scm.Perm{Admin: false, Push: false, Pull: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertWorkspaceRepoPerms(tt.from)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("convertWorkspaceRepoPerms() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -91,48 +206,40 @@ func TestRepositoryList(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
-		MatchParam("after", "PLACEHOLDER").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pageLen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "atlassian"}}], "next": ""}`)
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian").
 		MatchParam("pagelen", "1").
 		MatchParam("role", "member").
 		Reply(200).
 		Type("application/json").
 		File("testdata/repos-2.json")
 
-	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
-		MatchParam("pagelen", "1").
-		MatchParam("role", "member").
-		Reply(200).
-		Type("application/json").
-		File("testdata/repos.json")
-
-	got := []*scm.Repository{}
 	opts := scm.ListOptions{Size: 1}
 	client, _ := New("https://api.bitbucket.org")
 
-	for {
-		repos, res, err := client.Repositories.List(context.Background(), opts)
-		if err != nil {
-			t.Error(err)
-		}
-		got = append(got, repos...)
-
-		opts.Page = res.Page.Next
-		opts.URL = res.Page.NextURL
-
-		if opts.Page == 0 && opts.URL == "" {
-			break
-		}
+	got, _, err := client.Repositories.List(context.Background(), opts)
+	if err != nil {
+		t.Error(err)
 	}
 
-	want := []*scm.Repository{}
-	raw, _ := ioutil.ReadFile("testdata/repos.json.golden")
-	json.Unmarshal(raw, &want)
+	if len(got) != 1 {
+		t.Errorf("Expected 1 repository, got %d", len(got))
+	}
 
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Unexpected Results")
-		t.Log(diff)
+	if len(got) > 0 {
+		if got[0].Namespace != "atlassian" {
+			t.Errorf("Expected namespace 'atlassian', got '%s'", got[0].Namespace)
+		}
+		if got[0].Name != "stash-example-plugin" {
+			t.Errorf("Expected name 'stash-example-plugin', got '%s'", got[0].Name)
+		}
 	}
 }
 
@@ -140,7 +247,15 @@ func TestRepositoryListV2(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pageLen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "atlassian"}}], "next": ""}`)
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian").
 		MatchParam("q", "name~\\\"plugin1\\\"").
 		MatchParam("role", "member").
 		Reply(200).

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -111,6 +111,32 @@ func TestRepositoryPermsWithWorkspaceInURL(t *testing.T) {
 	}
 }
 
+func TestRepositoryPermsWithWorkspaceInURLAndFullRepoName(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/my-workspace/permissions/repositories/my-repo").
+		Reply(200).
+		Type("application/json").
+		File("testdata/workspace_repo_perms.json")
+
+	client, _ := New("https://api.bitbucket.org/repositories/my-workspace")
+	// Pass full repo name with workspace prefix - should extract just the repo slug
+	got, _, err := client.Repositories.FindPerms(context.Background(), "my-workspace/my-repo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := new(scm.Perm)
+	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
 func TestRepositoryPermsIterateWorkspaces(t *testing.T) {
 	defer gock.Off()
 
@@ -262,6 +288,16 @@ func TestRepositoryListV2(t *testing.T) {
 		Type("application/json").
 		File("testdata/repos_filter.json")
 
+	// Mock the pagination URL from the testdata
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories").
+		MatchParam("pagelen", "1").
+		MatchParam("after", "PLACEHOLDER").
+		MatchParam("role", "member").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [], "next": ""}`)
+
 	got := []*scm.Repository{}
 	opts := scm.RepoListOptions{RepoSearchTerm: scm.RepoSearchTerm{RepoName: "plugin1"}}
 	client, _ := New("https://api.bitbucket.org")
@@ -279,6 +315,59 @@ func TestRepositoryListV2(t *testing.T) {
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
+	}
+}
+
+func TestRepositoryListWithPartialWorkspaceFailure(t *testing.T) {
+	defer gock.Off()
+
+	// Mock fetching workspaces - returns two workspaces
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces").
+		MatchParam("page", "1").
+		MatchParam("pageLen", "100").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{"workspace": {"slug": "workspace-1"}}, {"workspace": {"slug": "workspace-2"}}], "next": ""}`)
+
+	// First workspace fails with 403
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/workspace-1").
+		MatchParam("pagelen", "1").
+		MatchParam("role", "member").
+		Reply(403).
+		Type("application/json").
+		BodyString(`{"error": {"message": "Access denied"}}`)
+
+	// Second workspace succeeds
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/workspace-2").
+		MatchParam("pagelen", "1").
+		MatchParam("role", "member").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repos-2.json")
+
+	opts := scm.ListOptions{Size: 1}
+	client, _ := New("https://api.bitbucket.org")
+
+	got, _, err := client.Repositories.List(context.Background(), opts)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Should still get repositories from workspace-2 even though workspace-1 failed
+	if len(got) != 1 {
+		t.Errorf("Expected 1 repository from accessible workspace, got %d", len(got))
+	}
+
+	if len(got) > 0 {
+		if got[0].Namespace != "atlassian" {
+			t.Errorf("Expected namespace 'atlassian', got '%s'", got[0].Namespace)
+		}
+		if got[0].Name != "stash-example-plugin" {
+			t.Errorf("Expected name 'stash-example-plugin', got '%s'", got[0].Name)
+		}
 	}
 }
 

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -231,18 +231,24 @@ func TestConvertWorkspaceRepoPerms(t *testing.T) {
 func TestRepositoryList(t *testing.T) {
 	defer gock.Off()
 
+	// Workspace list (sorted)
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
-		MatchParam("page", "1").
-		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "atlassian"}}], "next": ""}`)
 
+	// Count query (pagelen=1 to read "size" field)
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/repositories/atlassian").
 		MatchParam("pagelen", "1").
-		MatchParam("role", "member").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{}], "size": 1, "next": ""}`)
+
+	// Actual data fetch
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian").
 		Reply(200).
 		Type("application/json").
 		File("testdata/repos-2.json")
@@ -272,14 +278,22 @@ func TestRepositoryList(t *testing.T) {
 func TestRepositoryListV2(t *testing.T) {
 	defer gock.Off()
 
+	// Workspace list (sorted)
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
-		MatchParam("page", "1").
-		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "atlassian"}}], "next": ""}`)
 
+	// Count query (pagelen=1 to read "size" field)
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/atlassian").
+		MatchParam("pagelen", "1").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{}], "size": 1, "next": ""}`)
+
+	// Actual data fetch with search filter
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/repositories/atlassian").
 		MatchParam("q", "name~\\\"plugin1\\\"").
@@ -287,16 +301,6 @@ func TestRepositoryListV2(t *testing.T) {
 		Reply(200).
 		Type("application/json").
 		File("testdata/repos_filter.json")
-
-	// Mock the pagination URL from the testdata
-	gock.New("https://api.bitbucket.org").
-		Get("/2.0/repositories").
-		MatchParam("pagelen", "1").
-		MatchParam("after", "PLACEHOLDER").
-		MatchParam("role", "member").
-		Reply(200).
-		Type("application/json").
-		BodyString(`{"values": [], "next": ""}`)
 
 	got := []*scm.Repository{}
 	opts := scm.RepoListOptions{RepoSearchTerm: scm.RepoSearchTerm{RepoName: "plugin1"}}
@@ -321,29 +325,32 @@ func TestRepositoryListV2(t *testing.T) {
 func TestRepositoryListWithPartialWorkspaceFailure(t *testing.T) {
 	defer gock.Off()
 
-	// Mock fetching workspaces - returns two workspaces
+	// Workspace list (sorted)
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
-		MatchParam("page", "1").
-		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "workspace-1"}}, {"workspace": {"slug": "workspace-2"}}], "next": ""}`)
 
-	// First workspace fails with 403
+	// First workspace: count query fails with 403
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/repositories/workspace-1").
 		MatchParam("pagelen", "1").
-		MatchParam("role", "member").
 		Reply(403).
 		Type("application/json").
 		BodyString(`{"error": {"message": "Access denied"}}`)
 
-	// Second workspace succeeds
+	// Second workspace: count query succeeds
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/repositories/workspace-2").
 		MatchParam("pagelen", "1").
-		MatchParam("role", "member").
+		Reply(200).
+		Type("application/json").
+		BodyString(`{"values": [{}], "size": 1, "next": ""}`)
+
+	// Second workspace: actual data fetch
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/repositories/workspace-2").
 		Reply(200).
 		Type("application/json").
 		File("testdata/repos-2.json")

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -143,7 +143,7 @@ func TestRepositoryPermsIterateWorkspaces(t *testing.T) {
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
-		MatchParam("pageLen", "100").
+		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		File("testdata/user_workspaces.json")
@@ -234,7 +234,7 @@ func TestRepositoryList(t *testing.T) {
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
-		MatchParam("pageLen", "100").
+		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "atlassian"}}], "next": ""}`)
@@ -275,7 +275,7 @@ func TestRepositoryListV2(t *testing.T) {
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
-		MatchParam("pageLen", "100").
+		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "atlassian"}}], "next": ""}`)
@@ -325,7 +325,7 @@ func TestRepositoryListWithPartialWorkspaceFailure(t *testing.T) {
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
-		MatchParam("pageLen", "100").
+		MatchParam("pagelen", "100").
 		Reply(200).
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "workspace-1"}}, {"workspace": {"slug": "workspace-2"}}], "next": ""}`)

--- a/scm/driver/bitbucket/repo_workspace_pagination_test.go
+++ b/scm/driver/bitbucket/repo_workspace_pagination_test.go
@@ -1,0 +1,446 @@
+// Copyright 2026 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/drone/go-scm/scm"
+)
+
+// TestList_WorkspacePagination_SingleWorkspace tests pagination within a single workspace
+func TestList_WorkspacePagination_SingleWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mock workspace list endpoint (sorted)
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "workspace1"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		// Mock repository list for workspace1 (250 total repos, paginated)
+		if r.URL.Path == "/2.0/repositories/workspace1" {
+			page := r.URL.Query().Get("page")
+			pagelen := r.URL.Query().Get("pagelen")
+
+			if pagelen == "" {
+				pagelen = "10" // default
+			}
+
+			switch page {
+			case "", "1":
+				// Page 1: repos 0-99 (include total size)
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(createMockRepoPageWithSize("workspace1", 0, 100, "2", 250))
+			case "2":
+				// Page 2: repos 100-199
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(createMockRepoPageWithSize("workspace1", 100, 100, "3", 250))
+			case "3":
+				// Page 3: repos 200-249 (last page, partial)
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(createMockRepoPageWithSize("workspace1", 200, 50, "", 250))
+			}
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Page 1: Should get 100 repos
+	repos1, res1, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 1 error: %v", err)
+	}
+	if len(repos1) != 100 {
+		t.Errorf("Page 1: expected 100 repos, got %d", len(repos1))
+	}
+	if res1.Page.Next != 2 {
+		t.Errorf("Page 1: expected Next=2, got %d", res1.Page.Next)
+	}
+
+	// Page 2: Should get 100 repos
+	repos2, res2, err := client.Repositories.List(ctx, scm.ListOptions{Page: 2, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 2 error: %v", err)
+	}
+	if len(repos2) != 100 {
+		t.Errorf("Page 2: expected 100 repos, got %d", len(repos2))
+	}
+	if res2.Page.Next != 3 {
+		t.Errorf("Page 2: expected Next=3, got %d", res2.Page.Next)
+	}
+
+	// Page 3: Should get 50 repos (partial page)
+	repos3, res3, err := client.Repositories.List(ctx, scm.ListOptions{Page: 3, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 3 error: %v", err)
+	}
+	if len(repos3) != 50 {
+		t.Errorf("Page 3: expected 50 repos, got %d", len(repos3))
+	}
+	if res3.Page.Next != 0 {
+		t.Errorf("Page 3: expected Next=0 (no more pages), got %d", res3.Page.Next)
+	}
+}
+
+// TestList_WorkspacePagination_CrossWorkspace tests pagination across multiple workspaces
+func TestList_WorkspacePagination_CrossWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mock workspace list endpoint (sorted)
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws-alpha"}},
+					{"workspace": map[string]string{"slug": "ws-beta"}},
+					{"workspace": map[string]string{"slug": "ws-gamma"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		// ws-alpha: 150 repos (positions 0-149)
+		if r.URL.Path == "/2.0/repositories/ws-alpha" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws-alpha", 0, 150, "", 150))
+			return
+		}
+
+		// ws-beta: 120 repos (positions 150-269)
+		if r.URL.Path == "/2.0/repositories/ws-beta" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws-beta", 0, 120, "", 120))
+			return
+		}
+
+		// ws-gamma: 80 repos (positions 270-349)
+		if r.URL.Path == "/2.0/repositories/ws-gamma" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws-gamma", 0, 80, "", 80))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Page 1 (offset 0-99): All from ws-alpha
+	repos1, res1, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 1 error: %v", err)
+	}
+	if len(repos1) != 100 {
+		t.Errorf("Page 1: expected 100 repos, got %d", len(repos1))
+	}
+	if repos1[0].Namespace != "ws-alpha" {
+		t.Errorf("Page 1: expected first repo from ws-alpha, got %s", repos1[0].Namespace)
+	}
+	if res1.Page.Next != 2 {
+		t.Errorf("Page 1: expected Next=2, got %d", res1.Page.Next)
+	}
+
+	// Page 2 (offset 100-199): 50 from ws-alpha + 50 from ws-beta (boundary crossing!)
+	repos2, res2, err := client.Repositories.List(ctx, scm.ListOptions{Page: 2, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 2 error: %v", err)
+	}
+	if len(repos2) != 100 {
+		t.Errorf("Page 2: expected 100 repos, got %d", len(repos2))
+	}
+
+	// Verify workspace boundary crossing
+	alphaCount := 0
+	betaCount := 0
+	for _, repo := range repos2 {
+		if repo.Namespace == "ws-alpha" {
+			alphaCount++
+		} else if repo.Namespace == "ws-beta" {
+			betaCount++
+		}
+	}
+	if alphaCount != 50 {
+		t.Errorf("Page 2: expected 50 from ws-alpha, got %d", alphaCount)
+	}
+	if betaCount != 50 {
+		t.Errorf("Page 2: expected 50 from ws-beta, got %d", betaCount)
+	}
+	if res2.Page.Next != 3 {
+		t.Errorf("Page 2: expected Next=3, got %d", res2.Page.Next)
+	}
+
+	// Page 3 (offset 200-299): 70 from ws-beta + 30 from ws-gamma
+	repos3, res3, err := client.Repositories.List(ctx, scm.ListOptions{Page: 3, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 3 error: %v", err)
+	}
+	if len(repos3) != 100 {
+		t.Errorf("Page 3: expected 100 repos, got %d", len(repos3))
+	}
+
+	// Verify workspace boundary crossing
+	betaCount = 0
+	gammaCount := 0
+	for _, repo := range repos3 {
+		if repo.Namespace == "ws-beta" {
+			betaCount++
+		} else if repo.Namespace == "ws-gamma" {
+			gammaCount++
+		}
+	}
+	if betaCount != 70 {
+		t.Errorf("Page 3: expected 70 from ws-beta, got %d", betaCount)
+	}
+	if gammaCount != 30 {
+		t.Errorf("Page 3: expected 30 from ws-gamma, got %d", gammaCount)
+	}
+	if res3.Page.Next != 4 {
+		t.Errorf("Page 3: expected Next=4, got %d", res3.Page.Next)
+	}
+
+	// Page 4 (offset 300-349): 50 from ws-gamma (partial page, last page)
+	repos4, res4, err := client.Repositories.List(ctx, scm.ListOptions{Page: 4, Size: 100})
+	if err != nil {
+		t.Fatalf("Page 4 error: %v", err)
+	}
+	if len(repos4) != 50 {
+		t.Errorf("Page 4: expected 50 repos (partial), got %d", len(repos4))
+	}
+	if repos4[0].Namespace != "ws-gamma" {
+		t.Errorf("Page 4: expected repos from ws-gamma, got %s", repos4[0].Namespace)
+	}
+	if res4.Page.Next != 0 {
+		t.Errorf("Page 4: expected Next=0 (no more pages), got %d", res4.Page.Next)
+	}
+}
+
+// TestList_DefaultPage tests that Page=0 defaults to page 1
+func TestList_DefaultPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "ws1"}},
+					{"workspace": map[string]string{"slug": "ws2"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws1" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws1", 0, 50, "", 50))
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/ws2" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("ws2", 0, 30, "", 30))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Page=0 should default to page 1 and return first page worth of repos
+	repos, res, err := client.Repositories.List(ctx, scm.ListOptions{Page: 0, Size: 100})
+	if err != nil {
+		t.Fatalf("Default page error: %v", err)
+	}
+
+	// Should get 80 repos (50 from ws1 + 30 from ws2, total < page size)
+	if len(repos) != 80 {
+		t.Errorf("Default page: expected 80 repos, got %d", len(repos))
+	}
+
+	// No next page since 80 < 100
+	if res.Page.Next != 0 {
+		t.Errorf("Default page: expected Next=0, got %d", res.Page.Next)
+	}
+}
+
+// TestList_WorkspaceSorting tests that workspaces are consistently sorted
+func TestList_WorkspaceSorting(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			// Verify sort parameter is present
+			sort := r.URL.Query().Get("sort")
+			if sort != "workspace.slug" {
+				t.Errorf("Expected sort=workspace.slug, got: %s", sort)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "aaa-first"}},
+					{"workspace": map[string]string{"slug": "zzz-last"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/aaa-first" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("aaa-first", 0, 60, "", 60))
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/zzz-last" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("zzz-last", 0, 40, "", 40))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Page 1: Should get all 60 from aaa-first + 40 from zzz-last (fills to 100)
+	repos1, _, err := client.Repositories.List(ctx, scm.ListOptions{Page: 1, Size: 100})
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if len(repos1) != 100 {
+		t.Errorf("Expected 100 repos, got %d", len(repos1))
+	}
+
+	// Verify order: first 60 from aaa-first, then 40 from zzz-last
+	if repos1[0].Namespace != "aaa-first" {
+		t.Errorf("Expected first repo from aaa-first, got %s", repos1[0].Namespace)
+	}
+	if repos1[59].Namespace != "aaa-first" {
+		t.Errorf("Expected repo 59 from aaa-first, got %s", repos1[59].Namespace)
+	}
+	if repos1[60].Namespace != "zzz-last" {
+		t.Errorf("Expected repo 60 from zzz-last, got %s", repos1[60].Namespace)
+	}
+	if repos1[99].Namespace != "zzz-last" {
+		t.Errorf("Expected last repo from zzz-last, got %s", repos1[99].Namespace)
+	}
+}
+
+// TestListV2_WithSearchTerm tests pagination with search filter
+func TestListV2_WithSearchTerm(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/2.0/user/workspaces" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"values": []map[string]interface{}{
+					{"workspace": map[string]string{"slug": "workspace1"}},
+				},
+				"next": "",
+			})
+			return
+		}
+
+		if r.URL.Path == "/2.0/repositories/workspace1" {
+			// Verify search query is present
+			query := r.URL.Query().Get("q")
+			if query != `name~"test"` {
+				t.Errorf("Expected search query name~\"test\", got: %s", query)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(createMockRepoPageWithSize("workspace1", 0, 25, "", 25))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	ctx := context.Background()
+
+	// Test with search term
+	repos, _, err := client.Repositories.ListV2(ctx, scm.RepoListOptions{
+		RepoSearchTerm: scm.RepoSearchTerm{RepoName: "test"},
+		ListOptions:    scm.ListOptions{Page: 1, Size: 100},
+	})
+
+	if err != nil {
+		t.Fatalf("ListV2 error: %v", err)
+	}
+
+	if len(repos) != 25 {
+		t.Errorf("Expected 25 repos, got %d", len(repos))
+	}
+}
+
+// Helper function to create mock repository page response
+// workspace: workspace slug
+// startIdx: starting index for repo numbering
+// count: number of repos in this page
+// nextPage: next page number (empty if last page)
+// Optional: totalSize - total repos in workspace (for "size" field)
+func createMockRepoPage(workspace string, startIdx, count int, nextPage string) map[string]interface{} {
+	return createMockRepoPageWithSize(workspace, startIdx, count, nextPage, 0)
+}
+
+func createMockRepoPageWithSize(workspace string, startIdx, count int, nextPage string, totalSize int) map[string]interface{} {
+	values := []map[string]interface{}{}
+
+	for i := 0; i < count; i++ {
+		repoNum := startIdx + i
+		values = append(values, map[string]interface{}{
+			"uuid":       fmt.Sprintf("{repo-%d-uuid}", repoNum),
+			"full_name":  fmt.Sprintf("%s/repo-%d", workspace, repoNum),
+			"is_private": false,
+			"scm":        "git",
+			"links": map[string]interface{}{
+				"html":  map[string]string{"href": fmt.Sprintf("https://bitbucket.org/%s/repo-%d", workspace, repoNum)},
+				"clone": []map[string]string{},
+			},
+			"mainbranch": map[string]string{"name": "main"},
+		})
+	}
+
+	result := map[string]interface{}{
+		"values": values,
+		"next":   "",
+	}
+
+	// Add size field (total count) if provided
+	if totalSize > 0 {
+		result["size"] = totalSize
+		result["pagelen"] = 100
+		result["page"] = 1
+	}
+
+	if nextPage != "" {
+		result["next"] = fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s?page=%s&role=member", workspace, nextPage)
+	}
+
+	return result
+}

--- a/scm/driver/bitbucket/repo_workspace_pagination_test.go
+++ b/scm/driver/bitbucket/repo_workspace_pagination_test.go
@@ -285,16 +285,10 @@ func TestList_DefaultPage(t *testing.T) {
 	}
 }
 
-// TestList_WorkspaceSorting tests that workspaces are consistently sorted
-func TestList_WorkspaceSorting(t *testing.T) {
+// TestList_WorkspaceOrder tests that repos are returned in workspace order
+func TestList_WorkspaceOrder(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/2.0/user/workspaces" {
-			// Verify sort parameter is present
-			sort := r.URL.Query().Get("sort")
-			if sort != "workspace.slug" {
-				t.Errorf("Expected sort=workspace.slug, got: %s", sort)
-			}
-
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"values": []map[string]interface{}{

--- a/scm/driver/bitbucket/testdata/user_workspaces.json
+++ b/scm/driver/bitbucket/testdata/user_workspaces.json
@@ -1,0 +1,41 @@
+{
+  "pagelen": 30,
+  "values": [
+    {
+      "workspace": {
+        "slug": "my-workspace",
+        "name": "My Workspace",
+        "uuid": "{123e4567-e89b-12d3-a456-426614174000}",
+        "links": {
+          "avatar": {
+            "href": "https://bitbucket.org/account/my-workspace/avatar/32/"
+          },
+          "html": {
+            "href": "https://bitbucket.org/my-workspace/"
+          }
+        }
+      },
+      "permission": "owner",
+      "last_accessed": "2026-01-15T10:30:00.000000+00:00"
+    },
+    {
+      "workspace": {
+        "slug": "team-workspace",
+        "name": "Team Workspace",
+        "uuid": "{987fcdeb-51a2-43f7-9c8b-123456789abc}",
+        "links": {
+          "avatar": {
+            "href": "https://bitbucket.org/account/team-workspace/avatar/32/"
+          },
+          "html": {
+            "href": "https://bitbucket.org/team-workspace/"
+          }
+        }
+      },
+      "permission": "member",
+      "last_accessed": "2026-01-10T08:15:00.000000+00:00"
+    }
+  ],
+  "page": 1,
+  "next": ""
+}

--- a/scm/driver/bitbucket/testdata/user_workspaces.json.golden
+++ b/scm/driver/bitbucket/testdata/user_workspaces.json.golden
@@ -1,0 +1,10 @@
+[
+  {
+    "Name": "my-workspace",
+    "Avatar": "https://bitbucket.org/account/my-workspace/avatar/32/"
+  },
+  {
+    "Name": "team-workspace",
+    "Avatar": "https://bitbucket.org/account/team-workspace/avatar/32/"
+  }
+]

--- a/scm/driver/bitbucket/testdata/workspace_repo_perms.json
+++ b/scm/driver/bitbucket/testdata/workspace_repo_perms.json
@@ -1,0 +1,19 @@
+{
+  "values": [
+    {
+      "type": "repository_permission",
+      "user": {
+        "display_name": "Test User",
+        "uuid": "{d5bb8c49-f033-4498-910e-7e4b546b04ee}",
+        "nickname": "testuser"
+      },
+      "repository": {
+        "type": "repository",
+        "name": "stash-example-plugin",
+        "full_name": "atlassian/stash-example-plugin",
+        "uuid": "{a6e5e7d7-97ed-f751-cbd8-39d6bd4aef86}"
+      },
+      "permission": "admin"
+    }
+  ]
+}

--- a/scm/driver/bitbucket/testdata/workspace_repo_perms.json.golden
+++ b/scm/driver/bitbucket/testdata/workspace_repo_perms.json.golden
@@ -1,0 +1,5 @@
+{
+  "Pull": true,
+  "Push": true,
+  "Admin": true
+}

--- a/scm/driver/bitbucket/testdata/workspace_repo_perms_read.json
+++ b/scm/driver/bitbucket/testdata/workspace_repo_perms_read.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "type": "repository_permission",
+      "permission": "read"
+    }
+  ]
+}

--- a/scm/driver/bitbucket/testdata/workspace_repo_perms_write.json
+++ b/scm/driver/bitbucket/testdata/workspace_repo_perms_write.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "type": "repository_permission",
+      "permission": "write"
+    }
+  ]
+}

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -351,9 +351,10 @@ func (c *wrapper) determineHasMoreAndContinue(wsCount, localOffset, need, worksp
 // It makes a single lightweight API call (pagelen=1) and reads the "size" field
 // from Bitbucket's response. Falls back to counting pages if "size" is absent.
 func (c *wrapper) getWorkspaceRepoCount(ctx context.Context, workspaceSlug, queryParams string) (int, error) {
-	// Use pagelen=1 to minimise payload — we only need the "size" field
+	// Use pagelen=1 to minimise payload — we only need the "size" field.
 	params, _ := url.ParseQuery(queryParams)
 	params.Set("pagelen", "1")
+	params.Set("page", "1")
 	path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, params.Encode())
 
 	out := new(repositories)

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -5,6 +5,8 @@
 package bitbucket
 
 import (
+	"context"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -148,4 +150,101 @@ func copyPagination(from pagination, to *scm.Response) error {
 	to.Page.First = 1
 	to.Page.Next, _ = strconv.Atoi(page)
 	return nil
+}
+
+// workspaceAccessList represents the paginated response from /2.0/user/workspaces
+type workspaceAccessList struct {
+	pagination
+	Values []*workspaceAccess `json:"values"`
+}
+
+// workspaceAccess represents a single workspace access entry from /2.0/user/workspaces
+type workspaceAccess struct {
+	Workspace *workspace `json:"workspace"`
+}
+
+// workspace represents the nested workspace object in /2.0/user/workspaces response
+type workspace struct {
+	Slug  string `json:"slug"`
+	Links struct {
+		Avatar link `json:"avatar"`
+	} `json:"links"`
+}
+
+// fetchAllWorkspaces fetches all workspaces for the authenticated user
+func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
+	var workspaceSlugs []string
+	page := 1
+	pageLen := 100
+	for {
+		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pageLen=%d", page, pageLen)
+		workspaceStruct := new(workspaceAccessList)
+		_, err := c.do(ctx, "GET", path, nil, workspaceStruct)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, workspaceAccessResponse := range workspaceStruct.Values {
+			if workspaceAccessResponse.Workspace != nil && workspaceAccessResponse.Workspace.Slug != "" {
+				workspaceSlugs = append(workspaceSlugs, workspaceAccessResponse.Workspace.Slug)
+			}
+		}
+
+		// Check if there are more pages
+		if workspaceStruct.Next == "" {
+			break
+		}
+		page++
+	}
+
+	return workspaceSlugs, nil
+}
+
+// fetchReposFromAllWorkspaces fetches repositories from all user workspaces.
+func (c *wrapper) fetchReposFromAllWorkspaces(ctx context.Context, queryParams string) ([]*scm.Repository, *scm.Response, error) {
+	workspaces, err := c.fetchAllWorkspaces(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var allRepos []*scm.Repository
+	var lastRes *scm.Response
+
+	for _, workspaceSlug := range workspaces {
+		path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, queryParams)
+		out := new(repositories)
+		res, err := c.do(ctx, "GET", path, nil, &out)
+		if err != nil {
+			continue
+		}
+		allRepos = append(allRepos, convertRepositoryList(out)...)
+		lastRes = res
+	}
+
+	return allRepos, lastRes, nil
+}
+
+// extractWorkspaceFromURL attempts to extract workspace from the client's BaseURL path.
+func (c *wrapper) extractWorkspaceFromURL() string {
+	path := strings.Trim(c.BaseURL.Path, "/")
+	if path == "" {
+		return ""
+	}
+
+	parts := strings.Split(path, "/")
+
+	for i, part := range parts {
+		if part == "repositories" && i+1 < len(parts) && parts[i+1] != "" {
+			return parts[i+1]
+		}
+	}
+
+	if len(parts) > 0 {
+		last := parts[len(parts)-1]
+		if last != "" && last != "2.0" {
+			return last
+		}
+	}
+
+	return ""
 }

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -397,7 +397,7 @@ func (c *wrapper) fetchReposFromWorkspaceWithOffset(ctx context.Context, workspa
 	isFirstPage := true
 
 	for collected < limit {
-		repos, nextURL, err := c.fetchWorkspacePage(ctx, workspaceSlug, queryParams, bbPage)
+		repos, nextURL, err := c.fetchReposPageFromWorkspace(ctx, workspaceSlug, queryParams, bbPage)
 		if err != nil {
 			return result, err
 		}
@@ -406,14 +406,14 @@ func (c *wrapper) fetchReposFromWorkspaceWithOffset(ctx context.Context, workspa
 			break
 		}
 
-		start, shouldContinue := c.getSliceStartAndCheck(repos, skip, isFirstPage)
+		start, shouldContinue := c.getSliceStartIdxIfWithinLimits(repos, skip, isFirstPage)
 		if shouldContinue {
 			bbPage++
 			isFirstPage = false
 			continue
 		}
 
-		end := c.getSliceEnd(len(repos), start, limit, collected)
+		end := c.getSliceEndIdx(len(repos), start, limit, collected)
 		result = append(result, repos[start:end]...)
 		collected += end - start
 		isFirstPage = false
@@ -427,8 +427,8 @@ func (c *wrapper) fetchReposFromWorkspaceWithOffset(ctx context.Context, workspa
 	return result, nil
 }
 
-// getSliceStartAndCheck returns the starting index and whether to skip to next page.
-func (c *wrapper) getSliceStartAndCheck(repos []*scm.Repository, skip int, isFirstPage bool) (int, bool) {
+// getSliceStartIdxIfWithinLimits returns the starting index and whether to skip to next page.
+func (c *wrapper) getSliceStartIdxIfWithinLimits(repos []*scm.Repository, skip int, isFirstPage bool) (int, bool) {
 	start := 0
 	if isFirstPage && skip > 0 {
 		start = skip
@@ -439,8 +439,8 @@ func (c *wrapper) getSliceStartAndCheck(repos []*scm.Repository, skip int, isFir
 	return start, false
 }
 
-// getSliceEnd calculates the ending index for the slice to take.
-func (c *wrapper) getSliceEnd(reposLen, start, limit, collected int) int {
+// getSliceEndIdx calculates the ending index for the slice to take.
+func (c *wrapper) getSliceEndIdx(reposLen, start, limit, collected int) int {
 	end := reposLen
 	if end-start > limit-collected {
 		end = start + (limit - collected)
@@ -461,8 +461,8 @@ func extractPagelen(queryParams string) int {
 	return pagelen
 }
 
-// fetchWorkspacePage fetches a single page of repositories from a workspace.
-func (c *wrapper) fetchWorkspacePage(ctx context.Context, workspaceSlug, queryParams string, page int) ([]*scm.Repository, string, error) {
+// fetchReposPageFromWorkspace fetches a single page of repositories from a workspace.
+func (c *wrapper) fetchReposPageFromWorkspace(ctx context.Context, workspaceSlug, queryParams string, page int) ([]*scm.Repository, string, error) {
 	params, _ := url.ParseQuery(queryParams)
 	params.Set("page", strconv.Itoa(page))
 	path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, params.Encode())

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -210,14 +210,15 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 // determinism comes from always sorting workspaces by slug.
 //
 // Walk-through (Page 2, Size 100, ws1 has 150 repos, ws2 has 120):
-//   globalOffset = 100
-//   1. Get ws1 count → 150. cumulative=150. 150 > 100 → ws1 contains our start.
-//      localOffset in ws1 = 100. need = min(150-100, 100) = 50.
-//      Fetch 50 repos from ws1 at offset 100. remaining = 50.
-//   2. Get ws2 count → 120. cumulative=270. Need 50 more from ws2.
-//      localOffset in ws2 = 0. need = min(120, 50) = 50.
-//      Fetch 50 repos from ws2 at offset 0. remaining = 0. Done.
-//   hasMore = cumulative(270) > 100+100 → true → Next=3.
+//
+//	globalOffset = 100
+//	1. Get ws1 count → 150. cumulative=150. 150 > 100 → ws1 contains our start.
+//	   localOffset in ws1 = 100. need = min(150-100, 100) = 50.
+//	   Fetch 50 repos from ws1 at offset 100. remaining = 50.
+//	2. Get ws2 count → 120. cumulative=270. Need 50 more from ws2.
+//	   localOffset in ws2 = 0. need = min(120, 50) = 50.
+//	   Fetch 50 repos from ws2 at offset 0. remaining = 0. Done.
+//	hasMore = cumulative(270) > 100+100 → true → Next=3.
 func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams string, page, size int) ([]*scm.Repository, *scm.Response, error) {
 	workspaces, err := c.fetchAllWorkspaces(ctx)
 	if err != nil {
@@ -227,6 +228,7 @@ func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams stri
 		return []*scm.Repository{}, &scm.Response{}, nil
 	}
 
+	// Normalize page and size with sensible defaults
 	if size == 0 {
 		size = 100
 	}
@@ -235,88 +237,112 @@ func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams stri
 	}
 
 	globalOffset := (page - 1) * size
-
-	var (
-		result     []*scm.Repository
-		cumulative int  // running total of repos seen across workspaces
-		remaining  = size
-		hasMore    bool // whether more repos exist beyond this page
-	)
+	paginationState := &paginationState{
+		result:     make([]*scm.Repository, 0),
+		cumulative: 0,
+		remaining:  size,
+		hasMore:    false,
+	}
 
 	for i, workspaceSlug := range workspaces {
-		if remaining <= 0 {
-			// Page is full. If we reach here it means the previous workspace
-			// was exhausted exactly at our page boundary. We need to check if
-			// any remaining workspace has repos.
-			wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
-			if err == nil && wsCount > 0 {
-				hasMore = true
-			}
+		if !c.processPaginationWorkspace(ctx, queryParams, globalOffset, i, len(workspaces), workspaceSlug, paginationState) {
 			break
-		}
-
-		// Get this workspace's total repo count (single API call using Bitbucket's "size" field)
-		wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
-		if err != nil {
-			// Skip inaccessible workspace, continue with next
-			continue
-		}
-
-		wsStart := cumulative
-		cumulative += wsCount
-
-		// This workspace ends before our target range — skip it entirely, no repo fetch needed
-		if cumulative <= globalOffset {
-			continue
-		}
-
-		// Calculate how many repos we need from this workspace
-		localOffset := 0
-		if globalOffset > wsStart {
-			localOffset = globalOffset - wsStart
-		}
-		need := wsCount - localOffset
-		if need > remaining {
-			need = remaining
-		}
-
-		// Fetch only the slice we need using Bitbucket's page/pagelen math
-		repos, err := c.fetchReposFromWorkspaceWithOffset(ctx, workspaceSlug, queryParams, localOffset, need)
-		if err != nil {
-			continue
-		}
-
-		result = append(result, repos...)
-		remaining -= len(repos)
-
-		// Determine hasMore: either this workspace has leftover repos,
-		// or there are more workspaces after this one
-		if remaining <= 0 {
-			leftoverInWs := wsCount - (localOffset + need)
-			if leftoverInWs > 0 {
-				// Current workspace still has repos beyond what we took
-				hasMore = true
-			} else if i+1 < len(workspaces) {
-				// Current workspace exhausted exactly, but more workspaces remain.
-				// We don't know yet if they have repos — let the next loop iteration
-				// check with one cheap count call (the remaining<=0 block above).
-				continue
-			}
 		}
 	}
 
-	// Build response
 	res := &scm.Response{
 		Page: scm.Page{
 			First: 1,
 		},
 	}
-
-	if hasMore {
+	if paginationState.hasMore {
 		res.Page.Next = page + 1
 	}
 
-	return result, res, nil
+	return paginationState.result, res, nil
+}
+
+// paginationState tracks the progress of pagination across workspaces.
+type paginationState struct {
+	result     []*scm.Repository
+	cumulative int  // running total of repos seen across workspaces
+	remaining  int  // repos still needed to fill the page
+	hasMore    bool // whether more repos exist beyond this page
+}
+
+// processPaginationWorkspace processes a single workspace in pagination.
+// Returns false if pagination is complete, true to continue with next workspace.
+func (c *wrapper) processPaginationWorkspace(ctx context.Context, queryParams string, globalOffset, workspaceIndex, totalWorkspaces int, workspaceSlug string, state *paginationState) bool {
+	if state.remaining <= 0 {
+		return c.checkHasMoreRepos(ctx, workspaceSlug, queryParams, state)
+	}
+
+	wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
+	if err != nil {
+		return true
+	}
+
+	wsStart := state.cumulative
+	state.cumulative += wsCount
+
+	if state.cumulative <= globalOffset {
+		return true
+	}
+
+	localOffset := c.calculateLocalOffset(globalOffset, wsStart)
+	need := c.calculateReposNeeded(wsCount, localOffset, state.remaining)
+
+	repos, err := c.fetchReposFromWorkspaceWithOffset(ctx, workspaceSlug, queryParams, localOffset, need)
+	if err != nil {
+		return true
+	}
+
+	state.result = append(state.result, repos...)
+	state.remaining -= len(repos)
+
+	return c.determineHasMoreAndContinue(wsCount, localOffset, need, workspaceIndex, totalWorkspaces, state)
+}
+
+// checkHasMoreRepos checks if there are more repos when pagination is complete.
+func (c *wrapper) checkHasMoreRepos(ctx context.Context, workspaceSlug, queryParams string, state *paginationState) bool {
+	wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
+	if err == nil && wsCount > 0 {
+		state.hasMore = true
+	}
+	return false
+}
+
+// calculateLocalOffset returns the starting offset within a workspace.
+func (c *wrapper) calculateLocalOffset(globalOffset, wsStart int) int {
+	if globalOffset > wsStart {
+		return globalOffset - wsStart
+	}
+	return 0
+}
+
+// calculateReposNeeded returns how many repos are needed from this workspace.
+func (c *wrapper) calculateReposNeeded(wsCount, localOffset, remaining int) int {
+	need := wsCount - localOffset
+	if need > remaining {
+		return remaining
+	}
+	return need
+}
+
+// determineHasMoreAndContinue determines if more repos exist and whether to continue.
+func (c *wrapper) determineHasMoreAndContinue(wsCount, localOffset, need, workspaceIndex, totalWorkspaces int, state *paginationState) bool {
+	if state.remaining <= 0 {
+		leftoverInWs := wsCount - (localOffset + need)
+		if leftoverInWs > 0 {
+			state.hasMore = true
+			return false
+		}
+		if workspaceIndex+1 < totalWorkspaces {
+			return true
+		}
+		return false
+	}
+	return true
 }
 
 // getWorkspaceRepoCount returns the total number of repositories in a workspace.
@@ -360,7 +386,68 @@ func (c *wrapper) getWorkspaceRepoCount(ctx context.Context, workspaceSlug, quer
 //
 // Example: offset=150, pagelen=100  →  Bitbucket page 2, skip first 50 items.
 func (c *wrapper) fetchReposFromWorkspaceWithOffset(ctx context.Context, workspaceSlug, queryParams string, offset, limit int) ([]*scm.Repository, error) {
-	// Resolve the pagelen that Bitbucket will use for this workspace query
+	pagelen := extractPagelen(queryParams)
+	bbPage := (offset / pagelen) + 1
+	skip := offset % pagelen
+
+	var result []*scm.Repository
+	collected := 0
+	isFirstPage := true
+
+	for collected < limit {
+		repos, nextURL, err := c.fetchWorkspacePage(ctx, workspaceSlug, queryParams, bbPage)
+		if err != nil {
+			return result, err
+		}
+
+		if len(repos) == 0 {
+			break
+		}
+
+		start, shouldContinue := c.getSliceStartAndCheck(repos, skip, isFirstPage)
+		if shouldContinue {
+			bbPage++
+			isFirstPage = false
+			continue
+		}
+
+		end := c.getSliceEnd(len(repos), start, limit, collected)
+		result = append(result, repos[start:end]...)
+		collected += end - start
+		isFirstPage = false
+
+		if nextURL == "" {
+			break
+		}
+		bbPage++
+	}
+
+	return result, nil
+}
+
+// getSliceStartAndCheck returns the starting index and whether to skip to next page.
+func (c *wrapper) getSliceStartAndCheck(repos []*scm.Repository, skip int, isFirstPage bool) (int, bool) {
+	start := 0
+	if isFirstPage && skip > 0 {
+		start = skip
+		if start >= len(repos) {
+			return start, true
+		}
+	}
+	return start, false
+}
+
+// getSliceEnd calculates the ending index for the slice to take.
+func (c *wrapper) getSliceEnd(reposLen, start, limit, collected int) int {
+	end := reposLen
+	if end-start > limit-collected {
+		end = start + (limit - collected)
+	}
+	return end
+}
+
+// extractPagelen extracts the page length from query parameters, defaulting to 100.
+func extractPagelen(queryParams string) int {
 	pagelen := 100
 	if params, err := url.ParseQuery(queryParams); err == nil {
 		if v := params.Get("pagelen"); v != "" {
@@ -369,56 +456,22 @@ func (c *wrapper) fetchReposFromWorkspaceWithOffset(ctx context.Context, workspa
 			}
 		}
 	}
+	return pagelen
+}
 
-	// Translate logical offset into Bitbucket page number + skip count
-	bbPage := (offset / pagelen) + 1
-	skip := offset % pagelen
+// fetchWorkspacePage fetches a single page of repositories from a workspace.
+func (c *wrapper) fetchWorkspacePage(ctx context.Context, workspaceSlug, queryParams string, page int) ([]*scm.Repository, string, error) {
+	params, _ := url.ParseQuery(queryParams)
+	params.Set("page", strconv.Itoa(page))
+	path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, params.Encode())
 
-	var result []*scm.Repository
-	collected := 0
-
-	for collected < limit {
-		params, _ := url.ParseQuery(queryParams)
-		params.Set("page", strconv.Itoa(bbPage))
-		path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, params.Encode())
-
-		out := new(repositories)
-		_, err := c.do(ctx, "GET", path, nil, &out)
-		if err != nil {
-			return result, err
-		}
-
-		repos := convertRepositoryList(out)
-		if len(repos) == 0 {
-			break
-		}
-
-		// On the first fetched page, skip items before our logical offset
-		start := 0
-		if bbPage == (offset/pagelen)+1 && skip > 0 {
-			start = skip
-			if start >= len(repos) {
-				bbPage++
-				continue
-			}
-		}
-
-		// Take only what we still need
-		end := len(repos)
-		if end-start > limit-collected {
-			end = start + (limit - collected)
-		}
-
-		result = append(result, repos[start:end]...)
-		collected += end - start
-
-		if out.Next == "" {
-			break // workspace exhausted
-		}
-		bbPage++
+	out := new(repositories)
+	_, err := c.do(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return nil, "", err
 	}
 
-	return result, nil
+	return convertRepositoryList(out), out.Next, nil
 }
 
 // extractWorkspaceFromURL attempts to extract workspace from the client's BaseURL path.

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -172,15 +172,14 @@ type workspace struct {
 }
 
 // fetchAllWorkspaces fetches all workspaces for the authenticated user.
-// Workspaces are returned in sorted order by slug to ensure deterministic pagination behavior.
+// Workspaces are sorted by slug after fetching to ensure deterministic
+// pagination behavior across calls.
 func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 	var workspaceSlugs []string
 	page := 1
 	pageLen := 100
 	for {
-		// Sort by workspace.slug to ensure consistent ordering across requests
-		// This is critical for deterministic pagination across workspaces
-		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pagelen=%d&sort=workspace.slug", page, pageLen)
+		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pagelen=%d", page, pageLen)
 		workspaceStruct := new(workspaceAccessList)
 		_, err := c.do(ctx, "GET", path, nil, workspaceStruct)
 		if err != nil {
@@ -241,18 +240,19 @@ func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams stri
 		result     []*scm.Repository
 		cumulative int  // running total of repos seen across workspaces
 		remaining  = size
+		hasMore    bool // whether more repos exist beyond this page
 	)
 
-	for _, workspaceSlug := range workspaces {
+	for i, workspaceSlug := range workspaces {
 		if remaining <= 0 {
-			// Page is already full.
-			// We still need to know if more repos exist (for hasMore).
-			// One cheap count call is enough to answer that.
+			// Page is full. If we reach here it means the previous workspace
+			// was exhausted exactly at our page boundary. We need to check if
+			// any remaining workspace has repos.
 			wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
 			if err == nil && wsCount > 0 {
-				cumulative += wsCount
+				hasMore = true
 			}
-			break // we only need one more workspace to confirm hasMore
+			break
 		}
 
 		// Get this workspace's total repo count (single API call using Bitbucket's "size" field)
@@ -263,11 +263,10 @@ func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams stri
 		}
 
 		wsStart := cumulative
-		wsEnd := cumulative + wsCount
-		cumulative = wsEnd
+		cumulative += wsCount
 
 		// This workspace ends before our target range — skip it entirely, no repo fetch needed
-		if wsEnd <= globalOffset {
+		if cumulative <= globalOffset {
 			continue
 		}
 
@@ -289,6 +288,21 @@ func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams stri
 
 		result = append(result, repos...)
 		remaining -= len(repos)
+
+		// Determine hasMore: either this workspace has leftover repos,
+		// or there are more workspaces after this one
+		if remaining <= 0 {
+			leftoverInWs := wsCount - (localOffset + need)
+			if leftoverInWs > 0 {
+				// Current workspace still has repos beyond what we took
+				hasMore = true
+			} else if i+1 < len(workspaces) {
+				// Current workspace exhausted exactly, but more workspaces remain.
+				// We don't know yet if they have repos — let the next loop iteration
+				// check with one cheap count call (the remaining<=0 block above).
+				continue
+			}
+		}
 	}
 
 	// Build response
@@ -298,8 +312,7 @@ func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams stri
 		},
 	}
 
-	// There is a next page if total repos across workspaces exceed current page's end
-	if cumulative > globalOffset+size {
+	if hasMore {
 		res.Page.Next = page + 1
 	}
 

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -201,24 +201,40 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 }
 
 // fetchReposFromAllWorkspaces fetches repositories from all user workspaces.
+// It continues processing other workspaces even if one fails, returning partial results.
+// An error is only returned if fetching workspaces fails or if no repositories could be fetched at all.
 func (c *wrapper) fetchReposFromAllWorkspaces(ctx context.Context, queryParams string) ([]*scm.Repository, *scm.Response, error) {
 	workspaces, err := c.fetchAllWorkspaces(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var allRepos []*scm.Repository
-	var lastRes *scm.Response
+	if len(workspaces) == 0 {
+		return []*scm.Repository{}, nil, nil
+	}
+
+	var (
+		allRepos []*scm.Repository
+		lastRes  *scm.Response
+	)
 
 	for _, workspaceSlug := range workspaces {
+
 		path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, queryParams)
-		out := new(repositories)
-		res, err := c.do(ctx, "GET", path, nil, &out)
-		if err != nil {
-			continue
+
+		for path != "" {
+			out := new(repositories)
+
+			res, err := c.do(ctx, "GET", path, nil, &out)
+			if err != nil {
+				break
+			}
+
+			allRepos = append(allRepos, convertRepositoryList(out)...)
+			lastRes = res
+
+			path = out.Next
 		}
-		allRepos = append(allRepos, convertRepositoryList(out)...)
-		lastRes = res
 	}
 
 	return allRepos, lastRes, nil
@@ -241,7 +257,13 @@ func (c *wrapper) extractWorkspaceFromURL() string {
 
 	if len(parts) > 0 {
 		last := parts[len(parts)-1]
-		if last != "" && last != "2.0" {
+		excludedSegments := map[string]bool{
+			"2.0":        true,
+			"user":       true,
+			"workspaces": true,
+			"teams":      true,
+		}
+		if last != "" && !excludedSegments[last] {
 			return last
 		}
 	}

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -171,13 +171,16 @@ type workspace struct {
 	} `json:"links"`
 }
 
-// fetchAllWorkspaces fetches all workspaces for the authenticated user
+// fetchAllWorkspaces fetches all workspaces for the authenticated user.
+// Workspaces are returned in sorted order by slug to ensure deterministic pagination behavior.
 func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 	var workspaceSlugs []string
 	page := 1
 	pageLen := 100
 	for {
-		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pagelen=%d", page, pageLen)
+		// Sort by workspace.slug to ensure consistent ordering across requests
+		// This is critical for deterministic pagination across workspaces
+		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pagelen=%d&sort=workspace.slug", page, pageLen)
 		workspaceStruct := new(workspaceAccessList)
 		_, err := c.do(ctx, "GET", path, nil, workspaceStruct)
 		if err != nil {
@@ -200,44 +203,209 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 	return workspaceSlugs, nil
 }
 
-// fetchReposFromAllWorkspaces fetches repositories from all user workspaces.
-// It continues processing other workspaces even if one fails, returning partial results.
-// An error is only returned if fetching workspaces fails or if no repositories could be fetched at all.
-func (c *wrapper) fetchReposFromAllWorkspaces(ctx context.Context, queryParams string) ([]*scm.Repository, *scm.Response, error) {
+// fetchReposWithPagination fetches repositories with workspace-aware pagination.
+// Returns exactly 'size' repos (or fewer on the last page) by stitching across workspaces.
+//
+// The algorithm is lazy: it only queries a workspace when needed and stops
+// the moment the requested page is filled. Nothing is cached between calls;
+// determinism comes from always sorting workspaces by slug.
+//
+// Walk-through (Page 2, Size 100, ws1 has 150 repos, ws2 has 120):
+//   globalOffset = 100
+//   1. Get ws1 count → 150. cumulative=150. 150 > 100 → ws1 contains our start.
+//      localOffset in ws1 = 100. need = min(150-100, 100) = 50.
+//      Fetch 50 repos from ws1 at offset 100. remaining = 50.
+//   2. Get ws2 count → 120. cumulative=270. Need 50 more from ws2.
+//      localOffset in ws2 = 0. need = min(120, 50) = 50.
+//      Fetch 50 repos from ws2 at offset 0. remaining = 0. Done.
+//   hasMore = cumulative(270) > 100+100 → true → Next=3.
+func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams string, page, size int) ([]*scm.Repository, *scm.Response, error) {
 	workspaces, err := c.fetchAllWorkspaces(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	if len(workspaces) == 0 {
-		return []*scm.Repository{}, nil, nil
+		return []*scm.Repository{}, &scm.Response{}, nil
 	}
 
+	if size == 0 {
+		size = 100
+	}
+	if page == 0 {
+		page = 1
+	}
+
+	globalOffset := (page - 1) * size
+
 	var (
-		allRepos []*scm.Repository
-		lastRes  *scm.Response
+		result     []*scm.Repository
+		cumulative int  // running total of repos seen across workspaces
+		remaining  = size
 	)
 
 	for _, workspaceSlug := range workspaces {
-
-		path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, queryParams)
-
-		for path != "" {
-			out := new(repositories)
-
-			res, err := c.do(ctx, "GET", path, nil, &out)
-			if err != nil {
-				break
+		if remaining <= 0 {
+			// Page is already full.
+			// We still need to know if more repos exist (for hasMore).
+			// One cheap count call is enough to answer that.
+			wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
+			if err == nil && wsCount > 0 {
+				cumulative += wsCount
 			}
+			break // we only need one more workspace to confirm hasMore
+		}
 
-			allRepos = append(allRepos, convertRepositoryList(out)...)
-			lastRes = res
+		// Get this workspace's total repo count (single API call using Bitbucket's "size" field)
+		wsCount, err := c.getWorkspaceRepoCount(ctx, workspaceSlug, queryParams)
+		if err != nil {
+			// Skip inaccessible workspace, continue with next
+			continue
+		}
 
-			path = out.Next
+		wsStart := cumulative
+		wsEnd := cumulative + wsCount
+		cumulative = wsEnd
+
+		// This workspace ends before our target range — skip it entirely, no repo fetch needed
+		if wsEnd <= globalOffset {
+			continue
+		}
+
+		// Calculate how many repos we need from this workspace
+		localOffset := 0
+		if globalOffset > wsStart {
+			localOffset = globalOffset - wsStart
+		}
+		need := wsCount - localOffset
+		if need > remaining {
+			need = remaining
+		}
+
+		// Fetch only the slice we need using Bitbucket's page/pagelen math
+		repos, err := c.fetchReposFromWorkspaceWithOffset(ctx, workspaceSlug, queryParams, localOffset, need)
+		if err != nil {
+			continue
+		}
+
+		result = append(result, repos...)
+		remaining -= len(repos)
+	}
+
+	// Build response
+	res := &scm.Response{
+		Page: scm.Page{
+			First: 1,
+		},
+	}
+
+	// There is a next page if total repos across workspaces exceed current page's end
+	if cumulative > globalOffset+size {
+		res.Page.Next = page + 1
+	}
+
+	return result, res, nil
+}
+
+// getWorkspaceRepoCount returns the total number of repositories in a workspace.
+// It makes a single lightweight API call (pagelen=1) and reads the "size" field
+// from Bitbucket's response. Falls back to counting pages if "size" is absent.
+func (c *wrapper) getWorkspaceRepoCount(ctx context.Context, workspaceSlug, queryParams string) (int, error) {
+	// Use pagelen=1 to minimise payload — we only need the "size" field
+	params, _ := url.ParseQuery(queryParams)
+	params.Set("pagelen", "1")
+	path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, params.Encode())
+
+	out := new(repositories)
+	_, err := c.do(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return 0, err
+	}
+
+	// Bitbucket returns total count in "size"; prefer it when available
+	if out.Size > 0 {
+		return out.Size, nil
+	}
+
+	// Fallback: Bitbucket didn't provide size, count by paging through
+	count := len(out.Values)
+	next := out.Next
+	for next != "" {
+		page := new(repositories)
+		_, err := c.do(ctx, "GET", next, nil, &page)
+		if err != nil {
+			return count, nil
+		}
+		count += len(page.Values)
+		next = page.Next
+	}
+	return count, nil
+}
+
+// fetchReposFromWorkspaceWithOffset fetches `limit` repos from a workspace
+// starting at the given logical offset. It translates the offset into
+// Bitbucket page numbers and skips leading items on the first page.
+//
+// Example: offset=150, pagelen=100  →  Bitbucket page 2, skip first 50 items.
+func (c *wrapper) fetchReposFromWorkspaceWithOffset(ctx context.Context, workspaceSlug, queryParams string, offset, limit int) ([]*scm.Repository, error) {
+	// Resolve the pagelen that Bitbucket will use for this workspace query
+	pagelen := 100
+	if params, err := url.ParseQuery(queryParams); err == nil {
+		if v := params.Get("pagelen"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				pagelen = n
+			}
 		}
 	}
 
-	return allRepos, lastRes, nil
+	// Translate logical offset into Bitbucket page number + skip count
+	bbPage := (offset / pagelen) + 1
+	skip := offset % pagelen
+
+	var result []*scm.Repository
+	collected := 0
+
+	for collected < limit {
+		params, _ := url.ParseQuery(queryParams)
+		params.Set("page", strconv.Itoa(bbPage))
+		path := fmt.Sprintf("2.0/repositories/%s?%s", workspaceSlug, params.Encode())
+
+		out := new(repositories)
+		_, err := c.do(ctx, "GET", path, nil, &out)
+		if err != nil {
+			return result, err
+		}
+
+		repos := convertRepositoryList(out)
+		if len(repos) == 0 {
+			break
+		}
+
+		// On the first fetched page, skip items before our logical offset
+		start := 0
+		if bbPage == (offset/pagelen)+1 && skip > 0 {
+			start = skip
+			if start >= len(repos) {
+				bbPage++
+				continue
+			}
+		}
+
+		// Take only what we still need
+		end := len(repos)
+		if end-start > limit-collected {
+			end = start + (limit - collected)
+		}
+
+		result = append(result, repos[start:end]...)
+		collected += end - start
+
+		if out.Next == "" {
+			break // workspace exhausted
+		}
+		bbPage++
+	}
+
+	return result, nil
 }
 
 // extractWorkspaceFromURL attempts to extract workspace from the client's BaseURL path.

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -198,6 +199,7 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 		}
 		page++
 	}
+	sort.Strings(workspaceSlugs)
 
 	return workspaceSlugs, nil
 }

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -177,7 +177,7 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 	page := 1
 	pageLen := 100
 	for {
-		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pageLen=%d", page, pageLen)
+		path := fmt.Sprintf("2.0/user/workspaces?page=%d&pagelen=%d", page, pageLen)
 		workspaceStruct := new(workspaceAccessList)
 		_, err := c.do(ctx, "GET", path, nil, workspaceStruct)
 		if err != nil {

--- a/scm/driver/bitbucket/util_helpers_test.go
+++ b/scm/driver/bitbucket/util_helpers_test.go
@@ -240,51 +240,51 @@ func TestExtractPagelen(t *testing.T) {
 // TestGetSliceStartAndCheck tests the getSliceStartAndCheck helper function
 func TestGetSliceStartAndCheck(t *testing.T) {
 	tests := []struct {
-		name             string
-		reposLen         int
-		skip             int
-		isFirstPage      bool
-		wantStart        int
+		name               string
+		reposLen           int
+		skip               int
+		isFirstPage        bool
+		wantStart          int
 		wantShouldContinue bool
 	}{
 		{
-			name:             "first page with skip",
-			reposLen:         100,
-			skip:             30,
-			isFirstPage:      true,
-			wantStart:        30,
+			name:               "first page with skip",
+			reposLen:           100,
+			skip:               30,
+			isFirstPage:        true,
+			wantStart:          30,
 			wantShouldContinue: false,
 		},
 		{
-			name:             "first page no skip",
-			reposLen:         100,
-			skip:             0,
-			isFirstPage:      true,
-			wantStart:        0,
+			name:               "first page no skip",
+			reposLen:           100,
+			skip:               0,
+			isFirstPage:        true,
+			wantStart:          0,
 			wantShouldContinue: false,
 		},
 		{
-			name:             "not first page",
-			reposLen:         100,
-			skip:             30,
-			isFirstPage:      false,
-			wantStart:        0,
+			name:               "not first page",
+			reposLen:           100,
+			skip:               30,
+			isFirstPage:        false,
+			wantStart:          0,
 			wantShouldContinue: false,
 		},
 		{
-			name:             "skip exceeds page length",
-			reposLen:         100,
-			skip:             150,
-			isFirstPage:      true,
-			wantStart:        150,
+			name:               "skip exceeds page length",
+			reposLen:           100,
+			skip:               150,
+			isFirstPage:        true,
+			wantStart:          150,
 			wantShouldContinue: true,
 		},
 		{
-			name:             "skip equals page length",
-			reposLen:         100,
-			skip:             100,
-			isFirstPage:      true,
-			wantStart:        100,
+			name:               "skip equals page length",
+			reposLen:           100,
+			skip:               100,
+			isFirstPage:        true,
+			wantStart:          100,
 			wantShouldContinue: true,
 		},
 	}
@@ -295,7 +295,7 @@ func TestGetSliceStartAndCheck(t *testing.T) {
 			// Create dummy repos slice of appropriate length
 			repos := make([]*scm.Repository, tt.reposLen)
 
-			gotStart, gotShouldContinue := w.getSliceStartAndCheck(repos, tt.skip, tt.isFirstPage)
+			gotStart, gotShouldContinue := w.getSliceStartIdxIfWithinLimits(repos, tt.skip, tt.isFirstPage)
 
 			if gotStart != tt.wantStart {
 				t.Errorf("getSliceStartAndCheck() start = %d, want %d", gotStart, tt.wantStart)
@@ -363,7 +363,7 @@ func TestGetSliceEnd(t *testing.T) {
 	w := &wrapper{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := w.getSliceEnd(tt.reposLen, tt.start, tt.limit, tt.collected)
+			got := w.getSliceEndIdx(tt.reposLen, tt.start, tt.limit, tt.collected)
 			if got != tt.want {
 				t.Errorf("getSliceEnd(%d, %d, %d, %d) = %d, want %d",
 					tt.reposLen, tt.start, tt.limit, tt.collected, got, tt.want)
@@ -375,13 +375,13 @@ func TestGetSliceEnd(t *testing.T) {
 // TestCheckHasMoreRepos tests the checkHasMoreRepos helper function
 func TestCheckHasMoreRepos(t *testing.T) {
 	tests := []struct {
-		name             string
-		workspaceIndex   int
-		totalWorkspaces  int
-		workspaces       []string
-		setupMockCount   bool
-		mockCountResult  int
-		wantHasMore      bool
+		name            string
+		workspaceIndex  int
+		totalWorkspaces int
+		workspaces      []string
+		setupMockCount  bool
+		mockCountResult int
+		wantHasMore     bool
 	}{
 		{
 			name:            "last workspace",

--- a/scm/driver/bitbucket/util_helpers_test.go
+++ b/scm/driver/bitbucket/util_helpers_test.go
@@ -1,0 +1,556 @@
+// Copyright 2026 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/drone/go-scm/scm"
+)
+
+// TestCalculateLocalOffset tests the calculateLocalOffset helper function
+func TestCalculateLocalOffset(t *testing.T) {
+	tests := []struct {
+		name         string
+		globalOffset int
+		wsStart      int
+		want         int
+	}{
+		{
+			name:         "offset within workspace",
+			globalOffset: 150,
+			wsStart:      100,
+			want:         50,
+		},
+		{
+			name:         "offset at workspace start",
+			globalOffset: 100,
+			wsStart:      100,
+			want:         0,
+		},
+		{
+			name:         "offset before workspace",
+			globalOffset: 50,
+			wsStart:      100,
+			want:         0,
+		},
+		{
+			name:         "zero offset",
+			globalOffset: 0,
+			wsStart:      0,
+			want:         0,
+		},
+	}
+
+	w := &wrapper{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.calculateLocalOffset(tt.globalOffset, tt.wsStart)
+			if got != tt.want {
+				t.Errorf("calculateLocalOffset(%d, %d) = %d, want %d", tt.globalOffset, tt.wsStart, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCalculateReposNeeded tests the calculateReposNeeded helper function
+func TestCalculateReposNeeded(t *testing.T) {
+	tests := []struct {
+		name        string
+		wsCount     int
+		localOffset int
+		remaining   int
+		want        int
+	}{
+		{
+			name:        "need less than available",
+			wsCount:     100,
+			localOffset: 20,
+			remaining:   30,
+			want:        30,
+		},
+		{
+			name:        "need all available",
+			wsCount:     100,
+			localOffset: 20,
+			remaining:   80,
+			want:        80,
+		},
+		{
+			name:        "need more than available",
+			wsCount:     100,
+			localOffset: 20,
+			remaining:   100,
+			want:        80,
+		},
+		{
+			name:        "workspace exhausted at offset",
+			wsCount:     50,
+			localOffset: 50,
+			remaining:   10,
+			want:        0,
+		},
+		{
+			name:        "zero remaining",
+			wsCount:     100,
+			localOffset: 0,
+			remaining:   0,
+			want:        0,
+		},
+	}
+
+	w := &wrapper{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.calculateReposNeeded(tt.wsCount, tt.localOffset, tt.remaining)
+			if got != tt.want {
+				t.Errorf("calculateReposNeeded(%d, %d, %d) = %d, want %d", tt.wsCount, tt.localOffset, tt.remaining, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDetermineHasMoreAndContinue tests the determineHasMoreAndContinue helper function
+func TestDetermineHasMoreAndContinue(t *testing.T) {
+	tests := []struct {
+		name            string
+		wsCount         int
+		localOffset     int
+		need            int
+		workspaceIndex  int
+		totalWorkspaces int
+		remaining       int
+		wantHasMore     bool
+		wantContinue    bool
+	}{
+		{
+			name:            "still need more repos, continue",
+			wsCount:         100,
+			localOffset:     0,
+			need:            50,
+			workspaceIndex:  0,
+			totalWorkspaces: 3,
+			remaining:       10,
+			wantHasMore:     false,
+			wantContinue:    true,
+		},
+		{
+			name:            "page full, leftover in workspace",
+			wsCount:         100,
+			localOffset:     20,
+			need:            30,
+			workspaceIndex:  0,
+			totalWorkspaces: 3,
+			remaining:       0,
+			wantHasMore:     true,
+			wantContinue:    false,
+		},
+		{
+			name:            "page full, workspace exhausted, more workspaces",
+			wsCount:         100,
+			localOffset:     50,
+			need:            50,
+			workspaceIndex:  0,
+			totalWorkspaces: 3,
+			remaining:       0,
+			wantHasMore:     false,
+			wantContinue:    true,
+		},
+		{
+			name:            "page full, workspace exhausted, last workspace",
+			wsCount:         100,
+			localOffset:     50,
+			need:            50,
+			workspaceIndex:  2,
+			totalWorkspaces: 3,
+			remaining:       0,
+			wantHasMore:     false,
+			wantContinue:    false,
+		},
+	}
+
+	w := &wrapper{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &paginationState{remaining: tt.remaining}
+			gotContinue := w.determineHasMoreAndContinue(tt.wsCount, tt.localOffset, tt.need, tt.workspaceIndex, tt.totalWorkspaces, state)
+
+			if state.hasMore != tt.wantHasMore {
+				t.Errorf("determineHasMoreAndContinue() hasMore = %v, want %v", state.hasMore, tt.wantHasMore)
+			}
+
+			if gotContinue != tt.wantContinue {
+				t.Errorf("determineHasMoreAndContinue() continue = %v, want %v", gotContinue, tt.wantContinue)
+			}
+		})
+	}
+}
+
+// TestExtractPagelen tests the extractPagelen helper function
+func TestExtractPagelen(t *testing.T) {
+	tests := []struct {
+		name        string
+		queryParams string
+		want        int
+	}{
+		{
+			name:        "default pagelen",
+			queryParams: "",
+			want:        100,
+		},
+		{
+			name:        "custom pagelen",
+			queryParams: "pagelen=50",
+			want:        50,
+		},
+		{
+			name:        "pagelen in mixed params",
+			queryParams: "role=member&pagelen=25&page=2",
+			want:        25,
+		},
+		{
+			name:        "invalid pagelen",
+			queryParams: "pagelen=invalid",
+			want:        100,
+		},
+		{
+			name:        "negative pagelen",
+			queryParams: "pagelen=-10",
+			want:        100,
+		},
+		{
+			name:        "zero pagelen",
+			queryParams: "pagelen=0",
+			want:        100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPagelen(tt.queryParams)
+			if got != tt.want {
+				t.Errorf("extractPagelen(%q) = %d, want %d", tt.queryParams, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetSliceStartAndCheck tests the getSliceStartAndCheck helper function
+func TestGetSliceStartAndCheck(t *testing.T) {
+	tests := []struct {
+		name             string
+		reposLen         int
+		skip             int
+		isFirstPage      bool
+		wantStart        int
+		wantShouldContinue bool
+	}{
+		{
+			name:             "first page with skip",
+			reposLen:         100,
+			skip:             30,
+			isFirstPage:      true,
+			wantStart:        30,
+			wantShouldContinue: false,
+		},
+		{
+			name:             "first page no skip",
+			reposLen:         100,
+			skip:             0,
+			isFirstPage:      true,
+			wantStart:        0,
+			wantShouldContinue: false,
+		},
+		{
+			name:             "not first page",
+			reposLen:         100,
+			skip:             30,
+			isFirstPage:      false,
+			wantStart:        0,
+			wantShouldContinue: false,
+		},
+		{
+			name:             "skip exceeds page length",
+			reposLen:         100,
+			skip:             150,
+			isFirstPage:      true,
+			wantStart:        150,
+			wantShouldContinue: true,
+		},
+		{
+			name:             "skip equals page length",
+			reposLen:         100,
+			skip:             100,
+			isFirstPage:      true,
+			wantStart:        100,
+			wantShouldContinue: true,
+		},
+	}
+
+	w := &wrapper{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create dummy repos slice of appropriate length
+			repos := make([]*scm.Repository, tt.reposLen)
+
+			gotStart, gotShouldContinue := w.getSliceStartAndCheck(repos, tt.skip, tt.isFirstPage)
+
+			if gotStart != tt.wantStart {
+				t.Errorf("getSliceStartAndCheck() start = %d, want %d", gotStart, tt.wantStart)
+			}
+
+			if gotShouldContinue != tt.wantShouldContinue {
+				t.Errorf("getSliceStartAndCheck() shouldContinue = %v, want %v", gotShouldContinue, tt.wantShouldContinue)
+			}
+		})
+	}
+}
+
+// TestGetSliceEnd tests the getSliceEnd helper function
+func TestGetSliceEnd(t *testing.T) {
+	tests := []struct {
+		name      string
+		reposLen  int
+		start     int
+		limit     int
+		collected int
+		want      int
+	}{
+		{
+			name:      "take all remaining in page",
+			reposLen:  100,
+			start:     0,
+			limit:     100,
+			collected: 0,
+			want:      100,
+		},
+		{
+			name:      "take partial from page",
+			reposLen:  100,
+			start:     0,
+			limit:     50,
+			collected: 0,
+			want:      50,
+		},
+		{
+			name:      "already collected some",
+			reposLen:  100,
+			start:     0,
+			limit:     100,
+			collected: 70,
+			want:      30,
+		},
+		{
+			name:      "with offset and limit",
+			reposLen:  100,
+			start:     50,
+			limit:     80,
+			collected: 60,
+			want:      70,
+		},
+		{
+			name:      "exactly at limit",
+			reposLen:  100,
+			start:     0,
+			limit:     100,
+			collected: 100,
+			want:      0,
+		},
+	}
+
+	w := &wrapper{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.getSliceEnd(tt.reposLen, tt.start, tt.limit, tt.collected)
+			if got != tt.want {
+				t.Errorf("getSliceEnd(%d, %d, %d, %d) = %d, want %d",
+					tt.reposLen, tt.start, tt.limit, tt.collected, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckHasMoreRepos tests the checkHasMoreRepos helper function
+func TestCheckHasMoreRepos(t *testing.T) {
+	tests := []struct {
+		name             string
+		workspaceIndex   int
+		totalWorkspaces  int
+		workspaces       []string
+		setupMockCount   bool
+		mockCountResult  int
+		wantHasMore      bool
+	}{
+		{
+			name:            "last workspace",
+			workspaceIndex:  2,
+			totalWorkspaces: 3,
+			workspaces:      []string{"ws1", "ws2", "ws3"},
+			wantHasMore:     false,
+		},
+		{
+			name:            "not last workspace, has repos",
+			workspaceIndex:  0,
+			totalWorkspaces: 2,
+			workspaces:      []string{"ws1", "ws2"},
+			setupMockCount:  true,
+			mockCountResult: 10,
+			wantHasMore:     true,
+		},
+		{
+			name:            "not last workspace, no repos",
+			workspaceIndex:  0,
+			totalWorkspaces: 2,
+			workspaces:      []string{"ws1", "ws2"},
+			setupMockCount:  true,
+			mockCountResult: 0,
+			wantHasMore:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This test verifies the logic structure
+			// Actual integration testing is covered in other test files
+			hasMore := false
+
+			if tt.workspaceIndex+1 < tt.totalWorkspaces {
+				if tt.setupMockCount && tt.mockCountResult > 0 {
+					hasMore = true
+				}
+			}
+
+			if hasMore != tt.wantHasMore {
+				t.Errorf("checkHasMoreRepos logic: hasMore = %v, want %v", hasMore, tt.wantHasMore)
+			}
+		})
+	}
+}
+
+// TestPaginationState tests the paginationState struct behavior
+func TestPaginationState(t *testing.T) {
+	tests := []struct {
+		name      string
+		initial   paginationState
+		collected int
+		want      paginationState
+	}{
+		{
+			name: "collect repos",
+			initial: paginationState{
+				result:     []*scm.Repository{},
+				cumulative: 0,
+				remaining:  100,
+				hasMore:    false,
+			},
+			collected: 50,
+			want: paginationState{
+				result:     []*scm.Repository{},
+				cumulative: 0,
+				remaining:  50,
+				hasMore:    false,
+			},
+		},
+		{
+			name: "fill exactly",
+			initial: paginationState{
+				result:     []*scm.Repository{},
+				cumulative: 0,
+				remaining:  50,
+				hasMore:    false,
+			},
+			collected: 50,
+			want: paginationState{
+				result:     []*scm.Repository{},
+				cumulative: 0,
+				remaining:  0,
+				hasMore:    false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := tt.initial
+			state.remaining -= tt.collected
+
+			if state.remaining != tt.want.remaining {
+				t.Errorf("After collecting %d: remaining = %d, want %d",
+					tt.collected, state.remaining, tt.want.remaining)
+			}
+		})
+	}
+}
+
+// TestOffsetAndSkipCalculation tests offset/skip calculations used in fetchReposFromWorkspaceWithOffset
+func TestOffsetAndSkipCalculation(t *testing.T) {
+	tests := []struct {
+		name     string
+		offset   int
+		pagelen  int
+		wantPage int
+		wantSkip int
+	}{
+		{
+			name:     "offset 0",
+			offset:   0,
+			pagelen:  100,
+			wantPage: 1,
+			wantSkip: 0,
+		},
+		{
+			name:     "offset within first page",
+			offset:   50,
+			pagelen:  100,
+			wantPage: 1,
+			wantSkip: 50,
+		},
+		{
+			name:     "offset at page boundary",
+			offset:   100,
+			pagelen:  100,
+			wantPage: 2,
+			wantSkip: 0,
+		},
+		{
+			name:     "offset in middle of second page",
+			offset:   150,
+			pagelen:  100,
+			wantPage: 2,
+			wantSkip: 50,
+		},
+		{
+			name:     "large offset",
+			offset:   537,
+			pagelen:  100,
+			wantPage: 6,
+			wantSkip: 37,
+		},
+		{
+			name:     "custom pagelen",
+			offset:   175,
+			pagelen:  50,
+			wantPage: 4,
+			wantSkip: 25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPage := (tt.offset / tt.pagelen) + 1
+			gotSkip := tt.offset % tt.pagelen
+
+			if gotPage != tt.wantPage {
+				t.Errorf("page calculation: ((%d / %d) + 1) = %d, want %d",
+					tt.offset, tt.pagelen, gotPage, tt.wantPage)
+			}
+
+			if gotSkip != tt.wantSkip {
+				t.Errorf("skip calculation: (%d %% %d) = %d, want %d",
+					tt.offset, tt.pagelen, gotSkip, tt.wantSkip)
+			}
+		})
+	}
+}

--- a/scm/driver/bitbucket/util_test.go
+++ b/scm/driver/bitbucket/util_test.go
@@ -218,11 +218,24 @@ func Test_extractWorkspaceFromURL(t *testing.T) {
 			baseURL: "https://api.bitbucket.org/some-workspace",
 			want:    "some-workspace",
 		},
+		{
+			name:    "URL ending with user (excluded segment)",
+			baseURL: "https://api.bitbucket.org/2.0/user",
+			want:    "",
+		},
+		{
+			name:    "URL ending with workspaces (excluded segment)",
+			baseURL: "https://api.bitbucket.org/2.0/workspaces",
+			want:    "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			u, _ := url.Parse(tt.baseURL)
+			u, err := url.Parse(tt.baseURL)
+			if err != nil {
+				t.Fatalf("Failed to parse URL %q: %v", tt.baseURL, err)
+			}
 			if !strings.HasSuffix(u.Path, "/") {
 				u.Path = u.Path + "/"
 			}

--- a/scm/driver/bitbucket/util_test.go
+++ b/scm/driver/bitbucket/util_test.go
@@ -5,6 +5,8 @@
 package bitbucket
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/drone/go-scm/scm"
@@ -99,5 +101,136 @@ func Test_copyPagination(t *testing.T) {
 		if got, want := res.Page.Next, test.want.Next; got != want {
 			t.Errorf("Want Next page %d, got %d", want, got)
 		}
+	}
+}
+
+func Test_encodeListRoleOptions(t *testing.T) {
+	opts := scm.ListOptions{
+		Page: 10,
+		Size: 30,
+	}
+	want := "page=10&pagelen=30&role=member"
+	got := encodeListRoleOptions(opts)
+	if got != want {
+		t.Errorf("Want encoded list role options %q, got %q", want, got)
+	}
+}
+
+func Test_encodeRepoListOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts scm.RepoListOptions
+		want string
+	}{
+		{
+			name: "with repo search term",
+			opts: scm.RepoListOptions{
+				RepoSearchTerm: scm.RepoSearchTerm{RepoName: "test-repo"},
+				ListOptions:    scm.ListOptions{Page: 1, Size: 10},
+			},
+			want: "page=1&pagelen=10&q=name~%22test-repo%22&role=member",
+		},
+		{
+			name: "without search term",
+			opts: scm.RepoListOptions{
+				ListOptions: scm.ListOptions{Page: 2, Size: 20},
+			},
+			want: "page=2&pagelen=20&role=member",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := encodeRepoListOptions(tt.opts)
+			if got != tt.want {
+				t.Errorf("Want encoded repo list options %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_encodeBranchListOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts scm.BranchListOptions
+		want string
+	}{
+		{
+			name: "with search term",
+			opts: scm.BranchListOptions{
+				SearchTerm:      "feature",
+				PageListOptions: scm.ListOptions{Page: 1, Size: 10},
+			},
+			want: "page=1&pagelen=10&q=name~%22feature%22",
+		},
+		{
+			name: "without search term",
+			opts: scm.BranchListOptions{
+				PageListOptions: scm.ListOptions{Page: 2, Size: 20},
+			},
+			want: "page=2&pagelen=20",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := encodeBranchListOptions(tt.opts)
+			if got != tt.want {
+				t.Errorf("Want encoded branch list options %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_extractWorkspaceFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{
+			name:    "URL with repositories path",
+			baseURL: "https://api.bitbucket.org/repositories/my-workspace",
+			want:    "my-workspace",
+		},
+		{
+			name:    "URL with repositories and repo",
+			baseURL: "https://api.bitbucket.org/repositories/my-workspace/my-repo",
+			want:    "my-workspace",
+		},
+		{
+			name:    "URL with trailing slash",
+			baseURL: "https://api.bitbucket.org/my-workspace/",
+			want:    "my-workspace",
+		},
+		{
+			name:    "URL ending with 2.0",
+			baseURL: "https://api.bitbucket.org/2.0",
+			want:    "",
+		},
+		{
+			name:    "Empty path",
+			baseURL: "https://api.bitbucket.org",
+			want:    "",
+		},
+		{
+			name:    "URL with workspace slug at end",
+			baseURL: "https://api.bitbucket.org/some-workspace",
+			want:    "some-workspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.baseURL)
+			if !strings.HasSuffix(u.Path, "/") {
+				u.Path = u.Path + "/"
+			}
+			w := &wrapper{&scm.Client{BaseURL: u}}
+			got := w.extractWorkspaceFromURL()
+			if got != tt.want {
+				t.Errorf("extractWorkspaceFromURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
feat: [PIPE-32185]: handle deprecated cross-workspace API endpoints   
   - Replace /2.0/workspaces with /2.0/user/workspaces for org listing
   - Replace /2.0/repositories with workspace-scoped aggregation for repo listing
   - Replace /2.0/user/permissions/repositories with workspace-scoped endpoint
   - Add workspace extraction from client URL with fallback iteration

Testing : 
  - Service is starting & working
  - List Repos is working
  - PR is getting created

Screenshots : 
 
<img width="1728" height="620" alt="image" src="https://github.com/user-attachments/assets/19b6aa0d-4798-468b-901c-e95c49c65c9c" />
<img width="1728" height="654" alt="image" src="https://github.com/user-attachments/assets/92770287-4f4b-4b40-9efe-945120e722c3" />
<img width="879" height="723" alt="image" src="https://github.com/user-attachments/assets/9aba31d3-1a44-40ad-b1cd-08abb7237b27" />




[PIPE-32185]: https://harness.atlassian.net/browse/PIPE-32185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ