### PR TITLE
fix: [PIPE-32312]: add Bitbucket workspace extraction support

### DIFF
--- a/scm/driver/bitbucket/bitbucket.go
+++ b/scm/driver/bitbucket/bitbucket.go
@@ -26,7 +26,11 @@ func New(uri string) (*scm.Client, error) {
 	if !strings.HasSuffix(base.Path, "/") {
 		base.Path = base.Path + "/"
 	}
-	client := &wrapper{new(scm.Client)}
+	client := &wrapper{
+		Client:    new(scm.Client),
+		workspace: "",
+		repo:      "",
+	}
 	client.BaseURL = base
 	// initialize services
 	client.Driver = scm.DriverBitbucket
@@ -52,10 +56,22 @@ func NewDefault() *scm.Client {
 	return client
 }
 
+// SetWorkspace sets the workspace and repo for the Bitbucket client.
+// This allows the client to use workspace-specific API endpoints without
+// requiring account-level permissions.
+func SetWorkspace(client *scm.Client, workspace, repo string) {
+	if w, ok := client.Repositories.(*repositoryService); ok {
+		w.client.workspace = workspace
+		w.client.repo = repo
+	}
+}
+
 // wraper wraps the Client to provide high level helper functions
 // for making http requests and unmarshaling the response.
 type wrapper struct {
 	*scm.Client
+	workspace string // Bitbucket Cloud workspace extracted from connector URL
+	repo      string // Repository name extracted from connector URL (for repo-level connectors)
 }
 
 // do wraps the Client.Do function by creating the Request and

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -489,7 +489,14 @@ func (c *wrapper) fetchReposPageFromWorkspace(ctx context.Context, workspaceSlug
 }
 
 // extractWorkspaceFromURL attempts to extract workspace from the client's BaseURL path.
+// It first checks if workspace was explicitly set via SetWorkspace, then falls back to URL parsing.
 func (c *wrapper) extractWorkspaceFromURL() string {
+	// First, check if workspace was explicitly set via SetWorkspace
+	if c.workspace != "" {
+		return c.workspace
+	}
+
+	// Fall back to extracting from URL path
 	path := strings.Trim(c.BaseURL.Path, "/")
 	if path == "" {
 		return ""

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -222,10 +222,21 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 //	   Fetch 50 repos from ws2 at offset 0. remaining = 0. Done.
 //	hasMore = cumulative(270) > 100+100 → true → Next=3.
 func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams string, page, size int) ([]*scm.Repository, *scm.Response, error) {
-	workspaces, err := c.fetchAllWorkspaces(ctx)
-	if err != nil {
-		return nil, nil, err
+	var workspaces []string
+	var err error
+
+	// If workspace is configured in the client, use it directly instead of fetching all workspaces
+	// This allows repo-scoped tokens to work without requiring account scope
+	if c.workspace != "" {
+		workspaces = []string{c.workspace}
+	} else {
+		// Fall back to fetching all workspaces (requires account scope)
+		workspaces, err = c.fetchAllWorkspaces(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
+
 	if len(workspaces) == 0 {
 		return []*scm.Repository{}, &scm.Response{}, nil
 	}

--- a/scm/driver/bitbucket/util_helpers_test.go
+++ b/scm/driver/bitbucket/util_helpers_test.go
@@ -44,7 +44,7 @@ func TestCalculateLocalOffset(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{}
+	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := w.calculateLocalOffset(tt.globalOffset, tt.wsStart)
@@ -101,7 +101,7 @@ func TestCalculateReposNeeded(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{}
+	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := w.calculateReposNeeded(tt.wsCount, tt.localOffset, tt.remaining)
@@ -171,7 +171,7 @@ func TestDetermineHasMoreAndContinue(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{}
+	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &paginationState{remaining: tt.remaining}
@@ -289,7 +289,7 @@ func TestGetSliceStartAndCheck(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{}
+	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create dummy repos slice of appropriate length
@@ -360,7 +360,7 @@ func TestGetSliceEnd(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{}
+	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := w.getSliceEndIdx(tt.reposLen, tt.start, tt.limit, tt.collected)

--- a/scm/driver/bitbucket/util_test.go
+++ b/scm/driver/bitbucket/util_test.go
@@ -251,3 +251,58 @@ func Test_extractWorkspaceFromURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_extractWorkspaceFromURL_WithSetWorkspace(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseURL          string
+		explicitWorkspace string
+		want             string
+	}{
+		{
+			name:             "Explicit workspace set, should use it instead of URL",
+			baseURL:          "https://api.bitbucket.org",
+			explicitWorkspace: "harness-io",
+			want:             "harness-io",
+		},
+		{
+			name:             "Explicit workspace overrides URL workspace",
+			baseURL:          "https://api.bitbucket.org/repositories/old-workspace",
+			explicitWorkspace: "new-workspace",
+			want:             "new-workspace",
+		},
+		{
+			name:             "No explicit workspace, falls back to URL parsing",
+			baseURL:          "https://api.bitbucket.org/repositories/url-workspace",
+			explicitWorkspace: "",
+			want:             "url-workspace",
+		},
+		{
+			name:             "Explicit workspace with standard Bitbucket Cloud URL",
+			baseURL:          "https://api.bitbucket.org/2.0",
+			explicitWorkspace: "my-workspace",
+			want:             "my-workspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.baseURL)
+			if err != nil {
+				t.Fatalf("Failed to parse URL %q: %v", tt.baseURL, err)
+			}
+			if !strings.HasSuffix(u.Path, "/") {
+				u.Path = u.Path + "/"
+			}
+			w := &wrapper{
+				Client:    &scm.Client{BaseURL: u},
+				workspace: tt.explicitWorkspace,
+				repo:      "",
+			}
+			got := w.extractWorkspaceFromURL()
+			if got != tt.want {
+				t.Errorf("extractWorkspaceFromURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/scm/driver/bitbucket/util_test.go
+++ b/scm/driver/bitbucket/util_test.go
@@ -239,7 +239,11 @@ func Test_extractWorkspaceFromURL(t *testing.T) {
 			if !strings.HasSuffix(u.Path, "/") {
 				u.Path = u.Path + "/"
 			}
-			w := &wrapper{&scm.Client{BaseURL: u}}
+			w := &wrapper{
+				Client:    &scm.Client{BaseURL: u},
+				workspace: "",
+				repo:      "",
+			}
 			got := w.extractWorkspaceFromURL()
 			if got != tt.want {
 				t.Errorf("extractWorkspaceFromURL() = %q, want %q", got, tt.want)


### PR DESCRIPTION
This pull request enhances Bitbucket SCM client support for workspace- and repository-scoped credentials, making it easier to use repo-level tokens without requiring account-wide permissions. The main changes include extending the Bitbucket client to store workspace and repository information, adding a setter for these fields, and updating repository fetching logic and tests accordingly.

**Bitbucket Client Enhancements:**

- The `wrapper` struct now includes `workspace` and `repo` fields to store workspace and repository names, enabling support for workspace- or repo-scoped tokens. (`scm/driver/bitbucket/bitbucket.go`)
- Added a `SetWorkspace` function to allow setting the workspace and repo on the Bitbucket client, facilitating the use of workspace-specific API endpoints. (`scm/driver/bitbucket/bitbucket.go`)

**Repository Fetching Logic:**

- Modified `fetchReposWithPagination` to use the configured workspace directly if set, avoiding unnecessary API calls and supporting repo-scoped tokens. (`scm/driver/bitbucket/util.go`)

**Test Updates:**

- Updated all relevant test helpers and test cases to initialize the `wrapper` struct with the new `workspace` and `repo` fields for consistency and to ensure tests reflect the new structure. (`scm/driver/bitbucket/util_helpers_test.go`, `scm/driver/bitbucket/util_test.go`) [[1]](diffhunk://#diff-6f384b46297461074a012ff713a9e1b02124853f07149c93a9e11d8776aeb7adL47-R47) [[2]](diffhunk://#diff-6f384b46297461074a012ff713a9e1b02124853f07149c93a9e11d8776aeb7adL104-R104) [[3]](diffhunk://#diff-6f384b46297461074a012ff713a9e1b02124853f07149c93a9e11d8776aeb7adL174-R174) [[4]](diffhunk://#diff-6f384b46297461074a012ff713a9e1b02124853f07149c93a9e11d8776aeb7adL292-R292) [[5]](diffhunk://#diff-6f384b46297461074a012ff713a9e1b02124853f07149c93a9e11d8776aeb7adL363-R363) [[6]](diffhunk://#diff-fa7bba8ee9058a56553125062220c943470b52ee329755252c0491e1ff3fd284L242-R246)