### PR TITLE
fix: use non-admin endpoint for repository permission checks

### DIFF
--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -139,18 +139,14 @@ func (s *repositoryService) findPermsAcrossWorkspaces(ctx context.Context, repoS
 	for _, workspace := range workspaces {
 		perm, res, err := s.fetchRepoPerms(ctx, workspace, repoSlug)
 		if err != nil {
-			// If it's a 404, the repo doesn't exist in this workspace
-			if res != nil && res.Status == 404 {
-				continue
+			// If fetchRepoPerms returned an HTTP error (4xx/5xx), propagate it.
+			// If it returned a "no access" error (no HTTP response), try next workspace.
+			if res != nil && res.Status >= 400 && res.Status != 404 {
+				return nil, res, err
 			}
-			// For other errors (network, auth, etc.), return immediately
-			return nil, res, err
+			continue
 		}
-
-		// Return permissions if user has any access to the repository
-		if perm.Pull || perm.Push || perm.Admin {
-			return perm, res, nil
-		}
+		return perm, res, nil
 	}
 
 	return nil, nil, fmt.Errorf("repository %s not found in any workspace", repoSlug)
@@ -467,42 +463,51 @@ func convertFromState(from scm.State) string {
 	}
 }
 
-// workspaceRepoPerms represents the response from
-// GET /2.0/workspaces/{workspace}/permissions/repositories/{repo_slug}
-type workspaceRepoPerms struct {
-	Values []*workspaceRepoPerm `json:"values"`
-}
-
-type workspaceRepoPerm struct {
+// userRepoPermission represents a single entry from
+// GET /2.0/user/workspaces/{workspace}/permissions/repositories
+type userRepoPermission struct {
 	Permission string `json:"permission"` // "admin", "write", "read"
 }
 
-func convertWorkspaceRepoPerms(from *workspaceRepoPerms) *scm.Perm {
-	to := new(scm.Perm)
-	if len(from.Values) == 0 {
-		return to
-	}
-	switch from.Values[0].Permission {
-	case "admin":
-		to.Pull = true
-		to.Push = true
-		to.Admin = true
-	case "write":
-		to.Pull = true
-		to.Push = true
-	default:
-		to.Pull = true
-	}
-	return to
+type userRepoPermissions struct {
+	pagination
+	Values []*userRepoPermission `json:"values"`
 }
 
-// fetchRepoPerms fetches repository permissions for a given workspace and repo slug.
+// fetchRepoPerms determines the current user's permission level on a repository
+// by querying GET /2.0/user/workspaces/{workspace}/permissions/repositories
+// filtered by repository slug.
+//
+// This endpoint is NOT deprecated and works for any authenticated user,
+// unlike /2.0/workspaces/{workspace}/permissions/repositories/{repo_slug}
+// which requires workspace admin access.
 func (s *repositoryService) fetchRepoPerms(ctx context.Context, workspace, repoSlug string) (*scm.Perm, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/workspaces/%s/permissions/repositories/%s", workspace, repoSlug)
-	out := new(workspaceRepoPerms)
+	params := url.Values{}
+	params.Set("q", fmt.Sprintf("repository.slug=\"%s\"", repoSlug))
+	params.Set("pagelen", "1")
+	path := fmt.Sprintf("2.0/user/workspaces/%s/permissions/repositories?%s", workspace, params.Encode())
+
+	out := new(userRepoPermissions)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	if err != nil {
 		return nil, res, err
 	}
-	return convertWorkspaceRepoPerms(out), res, nil
+
+	if len(out.Values) == 0 {
+		return nil, res, fmt.Errorf("user does not have access to repository %s/%s", workspace, repoSlug)
+	}
+
+	perm := new(scm.Perm)
+	switch out.Values[0].Permission {
+	case "admin":
+		perm.Pull = true
+		perm.Push = true
+		perm.Admin = true
+	case "write":
+		perm.Pull = true
+		perm.Push = true
+	default:
+		perm.Pull = true
+	}
+	return perm, res, nil
 }

--- a/scm/driver/bitbucket/repo_findperms_test.go
+++ b/scm/driver/bitbucket/repo_findperms_test.go
@@ -11,11 +11,10 @@ import (
 	"github.com/h2non/gock"
 )
 
-// TestFindPerms_ErrorWhenAllWorkspaces404 tests the case where repo doesn't exist in any workspace
-func TestFindPerms_ErrorWhenAllWorkspaces404(t *testing.T) {
+// TestFindPerms_ErrorWhenAllWorkspacesEmpty tests the case where repo doesn't exist in any workspace
+func TestFindPerms_ErrorWhenAllWorkspacesEmpty(t *testing.T) {
 	defer gock.Off()
 
-	// Mock workspace list
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -24,18 +23,19 @@ func TestFindPerms_ErrorWhenAllWorkspaces404(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}, {"workspace": {"slug": "ws2"}}], "next": ""}`)
 
-	// Both workspaces return 404
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws1/permissions/repositories/nonexistent-repo").
-		Reply(404).
+		Get("/2.0/user/workspaces/ws1/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
 		Type("application/json").
-		BodyString(`{"error": {"message": "Repository not found"}}`)
+		File("testdata/user_repo_perm_empty.json")
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws2/permissions/repositories/nonexistent-repo").
-		Reply(404).
+		Get("/2.0/user/workspaces/ws2/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
 		Type("application/json").
-		BodyString(`{"error": {"message": "Repository not found"}}`)
+		File("testdata/user_repo_perm_empty.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	_, _, err := client.Repositories.FindPerms(context.Background(), "nonexistent-repo")
@@ -53,7 +53,6 @@ func TestFindPerms_ErrorWhenAllWorkspaces404(t *testing.T) {
 func TestFindPerms_ErrorWhenWorkspaceFetchFails(t *testing.T) {
 	defer gock.Off()
 
-	// Mock workspace list with error
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -70,11 +69,10 @@ func TestFindPerms_ErrorWhenWorkspaceFetchFails(t *testing.T) {
 	}
 }
 
-// TestFindPerms_NoPermissions tests when user has no permissions (empty values array)
+// TestFindPerms_NoPermissionsInAnyWorkspace tests when user has no permissions
 func TestFindPerms_NoPermissionsInAnyWorkspace(t *testing.T) {
 	defer gock.Off()
 
-	// Mock workspace list
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -83,18 +81,16 @@ func TestFindPerms_NoPermissionsInAnyWorkspace(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}], "next": ""}`)
 
-	// Workspace returns empty permissions (no access)
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
+		Get("/2.0/user/workspaces/ws1/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		BodyString(`{"values": []}`)
+		File("testdata/user_repo_perm_empty.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	_, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
 
-	// When user has no permissions, current implementation returns error
-	// because empty permissions don't satisfy the "has any access" check
 	if err == nil {
 		t.Fatal("Expected error when user has no permissions")
 	}
@@ -104,11 +100,10 @@ func TestFindPerms_NoPermissionsInAnyWorkspace(t *testing.T) {
 	}
 }
 
-// TestFindPerms_NetworkErrorInMiddleWorkspace tests partial network failure
+// TestFindPerms_NetworkErrorReturnsImmediately tests that API errors are returned immediately
 func TestFindPerms_NetworkErrorReturnsImmediately(t *testing.T) {
 	defer gock.Off()
 
-	// Mock workspace list
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -117,9 +112,9 @@ func TestFindPerms_NetworkErrorReturnsImmediately(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}, {"workspace": {"slug": "ws2"}}], "next": ""}`)
 
-	// First workspace returns 500 (not a 404)
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
+		Get("/2.0/user/workspaces/ws1/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(500).
 		Type("application/json").
 		BodyString(`{"error": {"message": "Internal server error"}}`)
@@ -127,9 +122,8 @@ func TestFindPerms_NetworkErrorReturnsImmediately(t *testing.T) {
 	client, _ := New("https://api.bitbucket.org")
 	_, res, err := client.Repositories.FindPerms(context.Background(), "test-repo")
 
-	// Should return error immediately, not continue to ws2
 	if err == nil {
-		t.Fatal("Expected error for non-404 failure")
+		t.Fatal("Expected error for server failure")
 	}
 
 	if res == nil || res.Status != 500 {
@@ -137,11 +131,10 @@ func TestFindPerms_NetworkErrorReturnsImmediately(t *testing.T) {
 	}
 }
 
-// TestFindPerms_With404ThenSuccess tests that iteration continues on 404
-func TestFindPerms_Continues404ToSuccess(t *testing.T) {
+// TestFindPerms_ContinuesToNextWorkspace tests that iteration continues across workspaces
+func TestFindPerms_ContinuesToNextWorkspace(t *testing.T) {
 	defer gock.Off()
 
-	// Mock workspace list
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -150,19 +143,21 @@ func TestFindPerms_Continues404ToSuccess(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "ws1"}}, {"workspace": {"slug": "ws2"}}], "next": ""}`)
 
-	// First workspace returns 404 (repo not in this workspace)
+	// ws1: no access
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
-		Reply(404).
-		Type("application/json").
-		BodyString(`{"error": {"message": "Not found"}}`)
-
-	// Second workspace has the repo with admin permissions
-	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws2/permissions/repositories/test-repo").
+		Get("/2.0/user/workspaces/ws1/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_empty.json")
+
+	// ws2: admin
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces/ws2/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_repo_perm_admin.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	perm, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
@@ -180,7 +175,6 @@ func TestFindPerms_Continues404ToSuccess(t *testing.T) {
 func TestFindPerms_EmptyWorkspaceList(t *testing.T) {
 	defer gock.Off()
 
-	// Mock empty workspace list
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -201,18 +195,16 @@ func TestFindPerms_EmptyWorkspaceList(t *testing.T) {
 	}
 }
 
-// TestFindPerms_WorkspaceInURLWithFullRepoPath tests that URL workspace is used
-// even when repo has workspace/repo format - it extracts just the repo slug
+// TestFindPerms_WorkspaceInURLExtractionWithSlash tests that URL workspace is used
 func TestFindPerms_WorkspaceInURLExtractionWithSlash(t *testing.T) {
 	defer gock.Off()
 
-	// When workspace is in URL and repo has workspace/repo format,
-	// it should use URL workspace and extract just the repo slug
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/url-workspace/permissions/repositories/actual-repo").
+		Get("/2.0/user/workspaces/url-workspace/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_admin.json")
 
 	client, _ := New("https://api.bitbucket.org/repositories/url-workspace")
 	perm, _, err := client.Repositories.FindPerms(context.Background(), "different-workspace/actual-repo")
@@ -224,28 +216,19 @@ func TestFindPerms_WorkspaceInURLExtractionWithSlash(t *testing.T) {
 	if !perm.Admin {
 		t.Error("Expected admin permissions")
 	}
-
-	// Verify the correct endpoint was called (url-workspace, not different-workspace)
-	if !gock.IsDone() {
-		pending := gock.Pending()
-		if len(pending) > 0 {
-			t.Errorf("Expected all mocks to be called, pending: %v", pending[0].Request().URLStruct)
-		}
-	}
 }
 
-// TestFindPerms_PriorityOfWorkspaceResolution tests that URL workspace takes priority
+// TestFindPerms_URLWorkspaceTakesPriority tests that URL workspace takes priority
 func TestFindPerms_URLWorkspaceTakesPriority(t *testing.T) {
 	defer gock.Off()
 
-	// URL workspace should take priority over repo identifier workspace
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/url-workspace/permissions/repositories/repo-slug").
+		Get("/2.0/user/workspaces/url-workspace/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_admin.json")
 
-	// Should NOT call identifier-workspace even though repo is "identifier-workspace/repo-slug"
 	client, _ := New("https://api.bitbucket.org/repositories/url-workspace")
 	perm, _, err := client.Repositories.FindPerms(context.Background(), "identifier-workspace/repo-slug")
 
@@ -256,21 +239,12 @@ func TestFindPerms_URLWorkspaceTakesPriority(t *testing.T) {
 	if !perm.Admin {
 		t.Error("Expected admin permissions from url-workspace")
 	}
-
-	// Verify the correct endpoint was called (url-workspace, not identifier-workspace)
-	if !gock.IsDone() {
-		pending := gock.Pending()
-		if len(pending) > 0 {
-			t.Errorf("Expected all mocks to be called, pending: %v", pending[0].Request().URLStruct)
-		}
-	}
 }
 
-// TestFindPerms_MultipleWorkspacesMultiplePages tests pagination in workspace fetching
+// TestFindPerms_WorkspacePagination tests pagination in workspace fetching
 func TestFindPerms_WorkspacePagination(t *testing.T) {
 	defer gock.Off()
 
-	// Mock workspace list with multiple pages
 	gock.New("https://api.bitbucket.org").
 		Get("/2.0/user/workspaces").
 		MatchParam("page", "1").
@@ -286,19 +260,21 @@ func TestFindPerms_WorkspacePagination(t *testing.T) {
 		Type("application/json").
 		BodyString(`{"values": [{"workspace": {"slug": "ws2"}}], "next": ""}`)
 
-	// First workspace returns 404
+	// ws1: no access
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws1/permissions/repositories/test-repo").
-		Reply(404).
-		Type("application/json").
-		BodyString(`{"error": {"message": "Not found"}}`)
-
-	// Second workspace (from page 2) has the repo
-	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/ws2/permissions/repositories/test-repo").
+		Get("/2.0/user/workspaces/ws1/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_empty.json")
+
+	// ws2: write
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces/ws2/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_repo_perm_write.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	perm, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
@@ -307,7 +283,7 @@ func TestFindPerms_WorkspacePagination(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	if !perm.Admin {
-		t.Error("Expected to find permissions from workspace on page 2")
+	if !perm.Push || !perm.Pull || perm.Admin {
+		t.Error("Expected write permissions from ws2")
 	}
 }

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -61,28 +61,89 @@ func TestRepositoryFind_NotFound(t *testing.T) {
 	}
 }
 
-func TestRepositoryPerms(t *testing.T) {
+func TestRepositoryPerms_Admin(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/atlassian/permissions/repositories/stash-example-plugin").
+		Get("/2.0/user/workspaces/atlassian/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_admin.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Repositories.FindPerms(context.Background(), "atlassian/stash-example-plugin")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
-	want := new(scm.Perm)
-	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
-	json.Unmarshal(raw, &want)
-
+	want := &scm.Perm{Pull: true, Push: true, Admin: true}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
+	}
+}
+
+func TestRepositoryPerms_Write(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces/atlassian/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_repo_perm_write.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	got, _, err := client.Repositories.FindPerms(context.Background(), "atlassian/stash-example-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &scm.Perm{Pull: true, Push: true, Admin: false}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestRepositoryPerms_Read(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces/atlassian/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_repo_perm_read.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	got, _, err := client.Repositories.FindPerms(context.Background(), "atlassian/stash-example-plugin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &scm.Perm{Pull: true, Push: false, Admin: false}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestRepositoryPerms_NoAccess(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/user/workspaces/atlassian/permissions/repositories").
+		MatchParam("pagelen", "1").
+		Reply(200).
+		Type("application/json").
+		File("testdata/user_repo_perm_empty.json")
+
+	client, _ := New("https://api.bitbucket.org")
+	_, _, err := client.Repositories.FindPerms(context.Background(), "atlassian/stash-example-plugin")
+	if err == nil {
+		t.Fatal("Expected error when user has no access")
 	}
 }
 
@@ -90,21 +151,19 @@ func TestRepositoryPermsWithWorkspaceInURL(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/my-workspace/permissions/repositories/my-repo").
+		Get("/2.0/user/workspaces/my-workspace/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_admin.json")
 
 	client, _ := New("https://api.bitbucket.org/repositories/my-workspace")
 	got, _, err := client.Repositories.FindPerms(context.Background(), "my-repo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
-	want := new(scm.Perm)
-	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
-	json.Unmarshal(raw, &want)
-
+	want := &scm.Perm{Pull: true, Push: true, Admin: true}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
@@ -115,22 +174,19 @@ func TestRepositoryPermsWithWorkspaceInURLAndFullRepoName(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/my-workspace/permissions/repositories/my-repo").
+		Get("/2.0/user/workspaces/my-workspace/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_admin.json")
 
 	client, _ := New("https://api.bitbucket.org/repositories/my-workspace")
-	// Pass full repo name with workspace prefix - should extract just the repo slug
 	got, _, err := client.Repositories.FindPerms(context.Background(), "my-workspace/my-repo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
-	want := new(scm.Perm)
-	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
-	json.Unmarshal(raw, &want)
-
+	want := &scm.Perm{Pull: true, Push: true, Admin: true}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
@@ -148,83 +204,32 @@ func TestRepositoryPermsIterateWorkspaces(t *testing.T) {
 		Type("application/json").
 		File("testdata/user_workspaces.json")
 
+	// my-workspace: no access
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/my-workspace/permissions/repositories/test-repo").
+		Get("/2.0/user/workspaces/my-workspace/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		BodyString(`{"values": []}`)
+		File("testdata/user_repo_perm_empty.json")
 
+	// team-workspace: admin
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces/team-workspace/permissions/repositories/test-repo").
+		Get("/2.0/user/workspaces/team-workspace/permissions/repositories").
+		MatchParam("pagelen", "1").
 		Reply(200).
 		Type("application/json").
-		File("testdata/workspace_repo_perms.json")
+		File("testdata/user_repo_perm_admin.json")
 
 	client, _ := New("https://api.bitbucket.org")
 	got, _, err := client.Repositories.FindPerms(context.Background(), "test-repo")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
-	want := new(scm.Perm)
-	raw, _ := ioutil.ReadFile("testdata/workspace_repo_perms.json.golden")
-	json.Unmarshal(raw, &want)
-
+	want := &scm.Perm{Pull: true, Push: true, Admin: true}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
-	}
-}
-
-func TestConvertWorkspaceRepoPerms(t *testing.T) {
-	tests := []struct {
-		name string
-		from *workspaceRepoPerms
-		want *scm.Perm
-	}{
-		{
-			name: "admin permission",
-			from: &workspaceRepoPerms{
-				Values: []*workspaceRepoPerm{
-					{Permission: "admin"},
-				},
-			},
-			want: &scm.Perm{Admin: true, Push: true, Pull: true},
-		},
-		{
-			name: "write permission",
-			from: &workspaceRepoPerms{
-				Values: []*workspaceRepoPerm{
-					{Permission: "write"},
-				},
-			},
-			want: &scm.Perm{Admin: false, Push: true, Pull: true},
-		},
-		{
-			name: "read permission",
-			from: &workspaceRepoPerms{
-				Values: []*workspaceRepoPerm{
-					{Permission: "read"},
-				},
-			},
-			want: &scm.Perm{Admin: false, Push: false, Pull: true},
-		},
-		{
-			name: "empty values",
-			from: &workspaceRepoPerms{
-				Values: []*workspaceRepoPerm{},
-			},
-			want: &scm.Perm{Admin: false, Push: false, Pull: false},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := convertWorkspaceRepoPerms(tt.from)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("convertWorkspaceRepoPerms() mismatch (-want +got):\n%s", diff)
-			}
-		})
 	}
 }
 

--- a/scm/driver/bitbucket/testdata/repo_as_list.json
+++ b/scm/driver/bitbucket/testdata/repo_as_list.json
@@ -1,0 +1,36 @@
+{
+  "pagelen": 1,
+  "size": 1,
+  "values": [
+    {
+      "scm": "git",
+      "uuid": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+      "full_name": "atlassian/stash-example-plugin",
+      "name": "stash-example-plugin",
+      "slug": "stash-example-plugin",
+      "is_private": true,
+      "created_on": "2013-04-15T03:05:05.595458+00:00",
+      "updated_on": "2018-04-01T16:36:35.970175+00:00",
+      "mainbranch": {
+        "type": "branch",
+        "name": "master"
+      },
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/atlassian/stash-example-plugin"
+        },
+        "clone": [
+          {
+            "href": "https://bitbucket.org/atlassian/stash-example-plugin.git",
+            "name": "https"
+          },
+          {
+            "href": "git@bitbucket.org:atlassian/stash-example-plugin.git",
+            "name": "ssh"
+          }
+        ]
+      }
+    }
+  ],
+  "page": 1
+}

--- a/scm/driver/bitbucket/testdata/repos_empty.json
+++ b/scm/driver/bitbucket/testdata/repos_empty.json
@@ -1,0 +1,6 @@
+{
+  "pagelen": 1,
+  "size": 0,
+  "values": [],
+  "page": 1
+}

--- a/scm/driver/bitbucket/testdata/user_repo_perm_admin.json
+++ b/scm/driver/bitbucket/testdata/user_repo_perm_admin.json
@@ -1,0 +1,22 @@
+{
+  "pagelen": 1,
+  "size": 1,
+  "values": [
+    {
+      "type": "repository_permission",
+      "user": {
+        "type": "user",
+        "display_name": "Test User",
+        "uuid": "{d5bb8c49-f033-4498-910e-7e4b546b04ee}"
+      },
+      "repository": {
+        "type": "repository",
+        "name": "stash-example-plugin",
+        "full_name": "atlassian/stash-example-plugin",
+        "uuid": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}"
+      },
+      "permission": "admin"
+    }
+  ],
+  "page": 1
+}

--- a/scm/driver/bitbucket/testdata/user_repo_perm_empty.json
+++ b/scm/driver/bitbucket/testdata/user_repo_perm_empty.json
@@ -1,0 +1,6 @@
+{
+  "pagelen": 1,
+  "size": 0,
+  "values": [],
+  "page": 1
+}

--- a/scm/driver/bitbucket/testdata/user_repo_perm_read.json
+++ b/scm/driver/bitbucket/testdata/user_repo_perm_read.json
@@ -1,0 +1,11 @@
+{
+  "pagelen": 1,
+  "size": 1,
+  "values": [
+    {
+      "type": "repository_permission",
+      "permission": "read"
+    }
+  ],
+  "page": 1
+}

--- a/scm/driver/bitbucket/testdata/user_repo_perm_write.json
+++ b/scm/driver/bitbucket/testdata/user_repo_perm_write.json
@@ -1,0 +1,11 @@
+{
+  "pagelen": 1,
+  "size": 1,
+  "values": [
+    {
+      "type": "repository_permission",
+      "permission": "write"
+    }
+  ],
+  "page": 1
+}


### PR DESCRIPTION
  ## Summary                                                                                                                                   
                                                                                                                                               
  - Replaces admin-only `GET /2.0/workspaces/{workspace}/permissions/repositories/{repo_slug}`                                                 
    with `GET /2.0/user/workspaces/{workspace}/permissions/repositories` for checking                                                          
    current user's repository permissions                                                                                                      
  - The old endpoint requires workspace admin access, causing 403/404 for non-admin users                                                      
  - The new endpoint works for any authenticated user (read, write, or admin)      

  Fixes #355                                                                                                                                   
  Related #354                                                                                                                                 
                                                                                                                                               
  ## What changed                                                                                                                              
                 
  - `fetchRepoPerms()` in `scm/driver/bitbucket/repo.go` — uses new Bitbucket endpoint                                                         
    `GET /2.0/user/workspaces/{workspace}/permissions/repositories?q=repository.slug="{repo}"`                                                 
  - `findPermsAcrossWorkspaces()` — simplified error handling                                 
  - Removed unused `workspaceRepoPerms` / `convertWorkspaceRepoPerms` structs                                                                  
  - Updated and added tests for all permission levels (admin, write, read, no access)        

## Reference
- https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022  
- https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3081