### PR TITLE
feat: [CODE-5445]: propagate provider node_id into scm.Repository and scm.PullRequest

### DIFF
--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -7,6 +7,7 @@ package bitbucket
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -171,6 +172,7 @@ func convertPullRequests(from *prs) []*scm.PullRequest {
 func convertPullRequest(from *pr) *scm.PullRequest {
 	return &scm.PullRequest{
 		Number: from.ID,
+		NodeID: strconv.Itoa(from.ID),
 		Title:  from.Title,
 		Body:   from.Description,
 		Sha:    from.Source.Commit.Hash,

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -304,6 +304,7 @@ func convertRepository(from *repository) *scm.Repository {
 	namespace, name := scm.Split(from.FullName)
 	return &scm.Repository{
 		ID:        from.UUID,
+		NodeID:    from.UUID,
 		Name:      name,
 		Namespace: namespace,
 		Link:      from.Links.HTML.Href,

--- a/scm/driver/bitbucket/testdata/pr.json.golden
+++ b/scm/driver/bitbucket/testdata/pr.json.golden
@@ -1,5 +1,6 @@
 {
   "Number": 4982,
+    "NodeID": "4982",
     "Title": "IOS date picker component duplicate March issue",
     "Body": "IOS date picker component duplicate March issue",
     "Sha": "31c54529bd80",

--- a/scm/driver/bitbucket/testdata/prs.json.golden
+++ b/scm/driver/bitbucket/testdata/prs.json.golden
@@ -1,6 +1,7 @@
 [
   {
     "Number": 4982,
+    "NodeID": "4982",
     "Title": "IOS date picker component duplicate March issue",
     "Body": "IOS date picker component duplicate March issue",
     "Sha": "31c54529bd80",

--- a/scm/driver/bitbucket/testdata/repo.json.golden
+++ b/scm/driver/bitbucket/testdata/repo.json.golden
@@ -1,5 +1,6 @@
 {
     "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+    "NodeID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
     "Namespace": "atlassian",
     "Name": "stash-example-plugin",
     "Perm": null,

--- a/scm/driver/bitbucket/testdata/repos.json.golden
+++ b/scm/driver/bitbucket/testdata/repos.json.golden
@@ -1,6 +1,7 @@
 [
     {
         "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+        "NodeID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
         "Namespace": "atlassian",
         "Name": "stash-example-plugin",
         "Perm": null,
@@ -14,6 +15,7 @@
     },
     {
         "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+        "NodeID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
         "Namespace": "atlassian",
         "Name": "stash-example-plugin",
         "Perm": null,

--- a/scm/driver/bitbucket/testdata/repos_filter.json.golden
+++ b/scm/driver/bitbucket/testdata/repos_filter.json.golden
@@ -1,6 +1,7 @@
 [
     {
         "ID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
+        "NodeID": "{7dd600e6-0d9c-4801-b967-cb4cc17359ff}",
         "Namespace": "atlassian",
         "Name": "stash-example-plugin1",
         "Perm": null,

--- a/scm/driver/bitbucket/testdata/webhooks/pipeline_hook_created.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pipeline_hook_created.json.golden
@@ -1,6 +1,7 @@
 {
   "Repo": {
     "ID": "{2b922c6d-3824-4e91-a7be-90c8b8392f84}",
+    "NodeID": "{2b922c6d-3824-4e91-a7be-90c8b8392f84}",
     "Namespace": "automationtestharness",
     "Name": "testrepo",
     "Clone": "https://bitbucket.org/automationtestharness/testrepo",
@@ -25,6 +26,7 @@
   },
   "Execution": {
     "Number": 4,
+    "NodeID": "4",
     "Status": "running",
     "Created": "2025-03-24T08:48:56.572438+00:00",
     "URL": "https://bitbucket.org/automationtestharness/testrepo/addon/pipelines/home#!/results/4"

--- a/scm/driver/bitbucket/testdata/webhooks/pipeline_hook_update.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pipeline_hook_update.json.golden
@@ -1,6 +1,7 @@
 {
   "Repo": {
     "ID": "{2b922c6d-3824-4e91-a7be-90c8b8392f84}",
+    "NodeID": "{2b922c6d-3824-4e91-a7be-90c8b8392f84}",
     "Namespace": "automationtestharness",
     "Name": "testrepo",
     "Clone": "https://bitbucket.org/automationtestharness/testrepo",
@@ -25,6 +26,7 @@
   },
   "Execution": {
     "Number": 4,
+    "NodeID": "4",
     "Status": "success",
     "Created": "2025-03-24T08:48:56.572438+00:00",
     "URL": "https://bitbucket.org/automationtestharness/testrepo/addon/pipelines/home#!/results/4"

--- a/scm/driver/bitbucket/testdata/webhooks/pr_comment_created.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_comment_created.json.golden
@@ -2,6 +2,7 @@
 	"Action": "created",
 	"Repo": {
 		"ID": "{4402cbae-7790-453a-b29e-5fcab61a84df}",
+		"NodeID": "{4402cbae-7790-453a-b29e-5fcab61a84df}",
 		"Namespace": "rutvijmehta-harness",
 		"Name": "spring-cloud-alibaba",
 		"Perm": null,
@@ -17,6 +18,7 @@
 	},
 	"Issue": {
 		"Number": 1,
+		"NodeID": "1",
 		"Title": "Update pom.xml",
 		"Body": "Test",
 		"Link": "https://bitbucket.org/rutvijmehta-harness/spring-cloud-alibaba/pull-requests/1",
@@ -33,6 +35,7 @@
 		},
 		"PullRequest": {
 			"Number": 1,
+			"NodeID": "1",
 			"Title": "Update pom.xml",
 			"Body": "Test",
 			"Sha": "b9437f32dddd",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_comment_deleted.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_comment_deleted.json.golden
@@ -2,6 +2,7 @@
 	"Action": "deleted",
 	"Repo": {
 		"ID": "{4402cbae-7790-453a-b29e-5fcab61a84df}",
+		"NodeID": "{4402cbae-7790-453a-b29e-5fcab61a84df}",
 		"Namespace": "rutvijmehta-harness",
 		"Name": "spring-cloud-alibaba",
 		"Perm": null,
@@ -17,6 +18,7 @@
 	},
 	"Issue": {
 		"Number": 1,
+		"NodeID": "1",
 		"Title": "Update pom.xml",
 		"Body": "Test",
 		"Link": "https://bitbucket.org/rutvijmehta-harness/spring-cloud-alibaba/pull-requests/1",
@@ -33,6 +35,7 @@
 		},
 		"PullRequest": {
 			"Number": 1,
+			"NodeID": "1",
 			"Title": "Update pom.xml",
 			"Body": "Test",
 			"Sha": "b9437f32dddd",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_created.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_created.json.golden
@@ -2,6 +2,7 @@
     "Action": "opened",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "1",
         "Title": "Awesome new feature",
         "Body": "made some changes",
         "Sha": "507a576e59b3",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_declined.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_declined.json.golden
@@ -2,6 +2,7 @@
     "Action": "closed",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 2,
+        "NodeID": "2",
         "Title": "update README",
         "Body": "",
         "Sha": "6ca9fe26898a",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_fulfilled.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_fulfilled.json.golden
@@ -2,6 +2,7 @@
     "Action": "merged",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "1",
         "Title": "Awesome new feature",
         "Body": "made some changes",
         "Sha": "0704fc5beccc",

--- a/scm/driver/bitbucket/testdata/webhooks/pr_updated.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_updated.json.golden
@@ -2,6 +2,7 @@
     "Action": "synchronized",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "1",
         "Title": "Awesome new feature",
         "Body": "made some changes",
         "Sha": "0704fc5beccc",

--- a/scm/driver/bitbucket/testdata/webhooks/push.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push.json.golden
@@ -4,6 +4,7 @@
     "After": "141977fedf5cf35aa290ac87d4b5177ac4cd9de1",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,

--- a/scm/driver/bitbucket/testdata/webhooks/push_branch_create.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_branch_create.json.golden
@@ -3,6 +3,7 @@
     "After": "141977fedf5cf35aa290ac87d4b5177ac4cd9de1",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,

--- a/scm/driver/bitbucket/testdata/webhooks/push_branch_delete.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_branch_delete.json.golden
@@ -5,6 +5,7 @@
     },
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,

--- a/scm/driver/bitbucket/testdata/webhooks/push_tag_create.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_tag_create.json.golden
@@ -3,6 +3,7 @@
     "After": "141977fedf5cf35aa290ac87d4b5177ac4cd9de1",
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,

--- a/scm/driver/bitbucket/testdata/webhooks/push_tag_delete.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/push_tag_delete.json.golden
@@ -5,6 +5,7 @@
     },
     "Repo": {
         "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "NodeID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
         "Namespace": "brydzewski",
         "Name": "foo",
         "Perm": null,

--- a/scm/driver/bitbucket/webhook.go
+++ b/scm/driver/bitbucket/webhook.go
@@ -746,6 +746,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 		},
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Private:   src.Repository.IsPrivate,
@@ -779,6 +780,7 @@ func convertBranchCreateHook(src *pushHook) *scm.BranchHook {
 		},
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Private:   src.Repository.IsPrivate,
@@ -807,6 +809,7 @@ func convertBranchDeleteHook(src *pushHook) *scm.BranchHook {
 		},
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Private:   src.Repository.IsPrivate,
@@ -835,6 +838,7 @@ func convertTagCreateHook(src *pushHook) *scm.TagHook {
 		},
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Private:   src.Repository.IsPrivate,
@@ -863,6 +867,7 @@ func convertTagDeleteHook(src *pushHook) *scm.TagHook {
 		},
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Private:   src.Repository.IsPrivate,
@@ -889,6 +894,7 @@ func convertPullRequestHook(src *webhook) *scm.PullRequestHook {
 		Action: scm.ActionOpen,
 		PullRequest: scm.PullRequest{
 			Number: src.PullRequest.ID,
+			NodeID: strconv.Itoa(src.PullRequest.ID),
 			Title:  src.PullRequest.Title,
 			Body:   src.PullRequest.Description,
 			Sha:    src.PullRequest.Source.Commit.Hash,
@@ -910,6 +916,7 @@ func convertPullRequestHook(src *webhook) *scm.PullRequestHook {
 		},
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Private:   src.Repository.IsPrivate,
@@ -931,6 +938,7 @@ func convertPrCommentHook(src *prCommentHook) *scm.IssueCommentHook {
 	dst := scm.IssueCommentHook{
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      src.Repository.Name,
 			Clone:     fmt.Sprintf("https://bitbucket.org/%s.git", src.Repository.FullName),
@@ -950,6 +958,7 @@ func convertPrCommentHook(src *prCommentHook) *scm.IssueCommentHook {
 			},
 			PullRequest: scm.PullRequest{
 				Number: src.PullRequest.ID,
+				NodeID: strconv.Itoa(src.PullRequest.ID),
 				Title:  src.PullRequest.Title,
 				Body:   src.PullRequest.Description,
 				Sha:    src.PullRequest.Source.Commit.Hash,
@@ -1003,6 +1012,7 @@ func convertBitbucketHook(src *pipelineHook) *scm.PipelineHook {
 	return &scm.PipelineHook{
 		Repo: scm.Repository{
 			ID:        src.Repository.UUID,
+			NodeID:    src.Repository.UUID,
 			Namespace: namespace,
 			Name:      name,
 			Clone:     src.Repository.Links.HTML.Href, // Assuming HTML link as Clone URL

--- a/scm/driver/github/pr.go
+++ b/scm/driver/github/pr.go
@@ -73,6 +73,7 @@ func (s *pullService) Create(ctx context.Context, repo string, input *scm.PullRe
 
 type pr struct {
 	Number  int    `json:"number"`
+	NodeID  string `json:"node_id"`
 	State   string `json:"state"`
 	Title   string `json:"title"`
 	Body    string `json:"body"`
@@ -146,6 +147,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 	}
 	return &scm.PullRequest{
 		Number: from.Number,
+		NodeID: from.NodeID,
 		Title:  from.Title,
 		Body:   from.Body,
 		Sha:    from.Head.Sha,

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -15,7 +15,8 @@ import (
 )
 
 type repository struct {
-	ID    int `json:"id"`
+	ID    int    `json:"id"`
+	NodeID string `json:"node_id"`
 	Owner struct {
 		ID        int    `json:"id"`
 		Login     string `json:"login"`
@@ -260,6 +261,7 @@ func convertRepository(from *repository) *scm.Repository {
 	}
 	return &scm.Repository{
 		ID:        strconv.Itoa(from.ID),
+		NodeID:    from.NodeID,
 		Name:      from.Name,
 		Namespace: from.Owner.Login,
 		Perm: &scm.Perm{

--- a/scm/driver/github/testdata/repos_filter.json.golden
+++ b/scm/driver/github/testdata/repos_filter.json.golden
@@ -1,6 +1,7 @@
 [
     {
         "ID": "508719340",
+        "NodeID": "R_kgDOHlJw7A",
         "Namespace": "user123",
         "Name": "testRepo2",
         "Perm": {

--- a/scm/driver/github/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/github/testdata/webhooks/branch_create.json.golden
@@ -5,6 +5,7 @@
   },
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/branch_delete.json.golden
+++ b/scm/driver/github/testdata/webhooks/branch_delete.json.golden
@@ -5,6 +5,7 @@
   },
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/comment.json.golden
+++ b/scm/driver/github/testdata/webhooks/comment.json.golden
@@ -2,6 +2,7 @@
    "Action":"created",
    "Repo":{
       "ID":"309651765",
+      "NodeID": "MDEwOlJlcG9zaXRvcnkzMDk2NTE3NjU=",
       "Namespace":"abc",
       "Name":"def-ci-webhook-test",
       "Perm":null,

--- a/scm/driver/github/testdata/webhooks/deployment.json.golden
+++ b/scm/driver/github/testdata/webhooks/deployment.json.golden
@@ -11,6 +11,7 @@
     },
     "Repo": {
         "ID": "135493233",
+        "NodeID": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM=",
         "Namespace": "Codertocat",
         "Name": "Hello-World",
         "Perm": null,

--- a/scm/driver/github/testdata/webhooks/deployment_commit.json.golden
+++ b/scm/driver/github/testdata/webhooks/deployment_commit.json.golden
@@ -11,6 +11,7 @@
     },
     "Repo": {
         "ID": "135493233",
+        "NodeID": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM=",
         "Namespace": "Codertocat",
         "Name": "Hello-World",
         "Perm": null,

--- a/scm/driver/github/testdata/webhooks/pipeline_hook.json.golden
+++ b/scm/driver/github/testdata/webhooks/pipeline_hook.json.golden
@@ -1,6 +1,7 @@
 {
   "Repo": {
     "ID": "335170389",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkzMzUxNzAzODk=",
     "Namespace": "shivamnegi94",
     "Name": "testrepo",
     "Clone": "https://github.com/shivamnegi94/testrepo.git",

--- a/scm/driver/github/testdata/webhooks/pr_closed.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_closed.json.golden
@@ -2,6 +2,7 @@
   "Action": "closed",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "this is an edit",
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",

--- a/scm/driver/github/testdata/webhooks/pr_edited.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_edited.json.golden
@@ -2,6 +2,7 @@
   "Action": "updated",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "this is an edit",
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",

--- a/scm/driver/github/testdata/webhooks/pr_labeled.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_labeled.json.golden
@@ -2,6 +2,7 @@
   "Action": "labeled",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "",
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",

--- a/scm/driver/github/testdata/webhooks/pr_opened.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_opened.json.golden
@@ -2,6 +2,7 @@
   "Action": "opened",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "",
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",

--- a/scm/driver/github/testdata/webhooks/pr_ready_for_review.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_ready_for_review.json.golden
@@ -2,6 +2,7 @@
   "Action": "review_ready",
   "Repo": {
     "ID": "498312568",
+    "NodeID": "R_kgDOHbOleA",
     "Namespace": "wings-software",
     "Name": "meet-git-sync-test",
     "Perm": null,
@@ -16,6 +17,7 @@
   },
   "PullRequest": {
     "Number": 38,
+    "NodeID": "PR_kwDOHbOleM5Y9vnK",
     "Title": "Update dgdggd.me",
     "Body": null,
     "Sha": "212015fb011c49a2913c4a1a860ce07c0821c362",

--- a/scm/driver/github/testdata/webhooks/pr_reopened.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_reopened.json.golden
@@ -2,6 +2,7 @@
   "Action": "reopened",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "this is an edit",
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",

--- a/scm/driver/github/testdata/webhooks/pr_review_edited.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_review_edited.json.golden
@@ -2,6 +2,7 @@
   "Action": "edited",
   "Repo": {
     "ID": "335170389",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkzMzUxNzAzODk=",
     "Namespace": "shivamnegi94",
     "Name": "testrepo",
     "Branch": "main",
@@ -16,6 +17,7 @@
   },
   "PullRequest": {
     "Number": 206,
+    "NodeID": "PR_kwDOE_pLVc6hG98f",
     "Title": "Update sacsac.yaml",
     "Body": null,
     "Sha": "9dc1b02c9b25bac779bdb2f31034f3f2421aa71d",

--- a/scm/driver/github/testdata/webhooks/pr_review_submitted.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_review_submitted.json.golden
@@ -2,6 +2,7 @@
   "Action": "submitted",
   "Repo": {
     "ID": "335170389",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkzMzUxNzAzODk=",
     "Namespace": "shivamnegi94",
     "Name": "testrepo",
     "Branch": "main",
@@ -14,6 +15,7 @@
   },
   "PullRequest": {
     "Number": 205,
+    "NodeID": "PR_kwDOE_pLVc6g4aH8",
     "Title": "Update NewSre_v1.yaml",
     "Body": null,
     "Sha": "adccd6c5030261b47e35d0d3798d4ed31a051f6d",

--- a/scm/driver/github/testdata/webhooks/pr_sync.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_sync.json.golden
@@ -2,6 +2,7 @@
   "Action": "synchronized",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "this is an edit",
     "Sha": "8102e371cd01cf668893cb2d04a04d52331b1dc9",

--- a/scm/driver/github/testdata/webhooks/pr_unlabeled.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_unlabeled.json.golden
@@ -2,6 +2,7 @@
   "Action": "unlabeled",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,
@@ -15,6 +16,7 @@
   },
   "PullRequest": {
     "Number": 1,
+    "NodeID": "MDExOlB1bGxSZXF1ZXN0MTk2ODY3ODIy",
     "Title": "Update .drone.yml",
     "Body": "",
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",

--- a/scm/driver/github/testdata/webhooks/push.json.golden
+++ b/scm/driver/github/testdata/webhooks/push.json.golden
@@ -4,6 +4,7 @@
   "After": "199eddf46df50de8d02e99bf1c5fdb4101338224",
   "Repo": {
     "ID": "135493233",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM=",
     "Namespace": "Codertocat",
     "Name": "Hello-World",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/push_branch_create.json.golden
+++ b/scm/driver/github/testdata/webhooks/push_branch_create.json.golden
@@ -5,6 +5,7 @@
   "After": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/push_branch_delete.json.golden
+++ b/scm/driver/github/testdata/webhooks/push_branch_delete.json.golden
@@ -4,6 +4,7 @@
   "After": "0000000000000000000000000000000000000000",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/push_tag.json.golden
+++ b/scm/driver/github/testdata/webhooks/push_tag.json.golden
@@ -5,6 +5,7 @@
   "After": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/push_tag_delete.json.golden
+++ b/scm/driver/github/testdata/webhooks/push_tag_delete.json.golden
@@ -4,6 +4,7 @@
   "After": "0000000000000000000000000000000000000000",
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_created.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_created.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_deleted.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_deleted.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_edited.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_edited.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_prereleased.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_prereleased.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_published.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_published.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_released.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_released.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/release_unpublished.json.golden
+++ b/scm/driver/github/testdata/webhooks/release_unpublished.json.golden
@@ -14,6 +14,7 @@
   },
   "Repo": {
     "ID": "530296249",
+    "NodeID": "R_kgDOH5utuQ",
     "Namespace": "vcalasansh",
     "Name": "harness-ngtriggers-test",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/github/testdata/webhooks/tag_create.json.golden
@@ -5,6 +5,7 @@
   },
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/testdata/webhooks/tag_delete.json.golden
+++ b/scm/driver/github/testdata/webhooks/tag_delete.json.golden
@@ -5,6 +5,7 @@
   },
   "Repo": {
     "ID": "13933572",
+    "NodeID": "MDEwOlJlcG9zaXRvcnkxMzkzMzU3Mg==",
     "Namespace": "bradrydzewski",
     "Name": "drone-test-go",
     "Perm": null,

--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -354,8 +354,9 @@ type (
 			Modified []string      `json:"modified"`
 		} `json:"commits"`
 		Repository struct {
-			ID    int64 `json:"id"`
-			Owner struct {
+			ID     int64  `json:"id"`
+			NodeID string `json:"node_id"`
+			Owner  struct {
 				Login     string `json:"login"`
 				AvatarURL string `json:"avatar_url"`
 			} `json:"owner"`
@@ -559,6 +560,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 		},
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,
@@ -586,6 +588,7 @@ func convertBranchHook(src *createDeleteHook) *scm.BranchHook {
 		},
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,
@@ -606,6 +609,7 @@ func convertTagHook(src *createDeleteHook) *scm.TagHook {
 		},
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,
@@ -624,6 +628,7 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 		// Action        Action
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,
@@ -659,6 +664,7 @@ func convertDeploymentHook(src *deploymentHook) *scm.DeployHook {
 		},
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,
@@ -693,6 +699,7 @@ func convertIssueCommentHook(src *issueCommentHook) *scm.IssueCommentHook {
 	dst := &scm.IssueCommentHook{
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,
@@ -731,6 +738,7 @@ func convertReleaseHook(src *releaseHook) *scm.ReleaseHook {
 		},
 		Repo: scm.Repository{
 			ID:         fmt.Sprint(src.Repository.ID),
+			NodeID:     src.Repository.NodeID,
 			Namespace:  src.Repository.Owner.Login,
 			Name:       src.Repository.Name,
 			Branch:     src.Repository.DefaultBranch,

--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/drone/go-scm/scm"
@@ -108,6 +109,7 @@ func (s *pullService) Close(ctx context.Context, repo string, number int) (*scm.
 }
 
 type pr struct {
+	ID             int    `json:"id"`
 	Number         int    `json:"iid"`
 	Sha            string `json:"sha"`
 	Title          string `json:"title"`
@@ -163,6 +165,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 	}
 	return &scm.PullRequest{
 		Number: from.Number,
+		NodeID: strconv.Itoa(from.ID),
 		Title:  from.Title,
 		Body:   from.Desc,
 		Sha:    from.Sha,

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -202,6 +202,7 @@ func convertRepositoryList(from []*repository) []*scm.Repository {
 func convertRepository(from *repository) *scm.Repository {
 	to := &scm.Repository{
 		ID:         strconv.Itoa(from.ID),
+		NodeID:     strconv.Itoa(from.ID),
 		Namespace:  from.Namespace.Path,
 		Name:       from.Path,
 		Branch:     from.DefaultBranch,

--- a/scm/driver/gitlab/testdata/merge.json.golden
+++ b/scm/driver/gitlab/testdata/merge.json.golden
@@ -1,5 +1,6 @@
 {
     "Number": 1,
+    "NodeID": "239450",
     "Title": "JS fix",
     "Body": "Signed-off-by: Dmitriy Zaporozhets \u003cdmitriy.zaporozhets@gmail.com\u003e",
     "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",

--- a/scm/driver/gitlab/testdata/merges.json.golden
+++ b/scm/driver/gitlab/testdata/merges.json.golden
@@ -1,6 +1,7 @@
 [
     {
         "Number": 1,
+        "NodeID": "239450",
         "Title": "JS fix",
         "Body": "Signed-off-by: Dmitriy Zaporozhets \u003cdmitriy.zaporozhets@gmail.com\u003e",
         "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",

--- a/scm/driver/gitlab/testdata/repo.json.golden
+++ b/scm/driver/gitlab/testdata/repo.json.golden
@@ -1,5 +1,6 @@
 {
     "ID": "178504",
+    "NodeID": "178504",
     "Namespace": "diaspora",
     "Name": "diaspora",
     "Perm": {

--- a/scm/driver/gitlab/testdata/repos.json.golden
+++ b/scm/driver/gitlab/testdata/repos.json.golden
@@ -1,6 +1,7 @@
 [
     {
         "ID": "178504",
+        "NodeID": "178504",
         "Namespace": "diaspora",
         "Name": "diaspora",
         "Perm": {

--- a/scm/driver/gitlab/testdata/repos_filter.json.golden
+++ b/scm/driver/gitlab/testdata/repos_filter.json.golden
@@ -1,6 +1,7 @@
 [
     {
         "ID": "178504",
+        "NodeID": "178504",
         "Namespace": "diaspora",
         "Name": "diaspora",
         "Perm": {

--- a/scm/driver/gitlab/testdata/subgroup.json.golden
+++ b/scm/driver/gitlab/testdata/subgroup.json.golden
@@ -1,5 +1,6 @@
 {
     "ID": "14264161",
+    "NodeID": "14264161",
     "Namespace": "gitlab-org/gitter",
     "Name": "gitter-demo-app",
     "Perm": {

--- a/scm/driver/gitlab/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/branch_create.json.golden
@@ -4,6 +4,7 @@
     "After": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,

--- a/scm/driver/gitlab/testdata/webhooks/branch_delete.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/branch_delete.json.golden
@@ -5,6 +5,7 @@
   },
   "Repo": {
     "ID": "4861503",
+    "NodeID": "4861503",
     "Namespace": "gitlab-org",
     "Name": "hello-world",
     "Perm": null,

--- a/scm/driver/gitlab/testdata/webhooks/merge_request_comment_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/merge_request_comment_create.json.golden
@@ -2,6 +2,7 @@
     "Action": "created",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,
@@ -33,6 +34,7 @@
         },
         "PullRequest": {
             "Number": 1,
+            "NodeID": "6632669",
             "Title": "update readme",
             "Body": "adding build instructions to readme",
             "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",

--- a/scm/driver/gitlab/testdata/webhooks/pipeline_hook.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pipeline_hook.json.golden
@@ -1,6 +1,7 @@
 {
   "repo": {
     "id": "1",
+    "nodeID": "1",
     "namespace": "gitlab-org",
     "name": "gitlab-test",
     "clone": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
@@ -36,6 +37,7 @@
   },
   "PullRequest": {
     "Number": 371997275,
+    "NodeID": "371997275",
     "Title": "Edit test.txt",
     "Sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
     "Ref": "master",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_close.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_close.json.golden
@@ -2,6 +2,7 @@
     "Action": "closed",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "6632669",
         "Title": "update readme",
         "Body": "adding build instructions to readme",
         "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_create.json.golden
@@ -2,6 +2,7 @@
     "Action": "opened",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "6632669",
         "Title": "update readme",
         "Body": "adding build instructions to readme",
         "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_merge.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_merge.json.golden
@@ -2,6 +2,7 @@
     "Action": "merged",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "6632669",
         "Title": "update readme",
         "Body": "adding build instructions to readme",
         "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json.golden
@@ -2,6 +2,7 @@
     "Action": "reopened",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 1,
+        "NodeID": "6632669",
         "Title": "update readme",
         "Body": "adding build instructions to readme",
         "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_review_ready.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_review_ready.json.golden
@@ -2,6 +2,7 @@
     "Action": "review_ready",
     "Repo": {
         "ID": "44067058",
+        "NodeID": "44067058",
         "Namespace": "rathod.meetsatish",
         "Name": "meet",
         "Perm": null,
@@ -15,6 +16,7 @@
     },
     "PullRequest": {
         "Number": 3,
+        "NodeID": "248466002",
         "Title": "Draft: Update README.md",
         "Body": "",
         "Sha": "ffd71529ecdfb41a530ee13f91b8fdd3e743c754",

--- a/scm/driver/gitlab/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/push.json.golden
@@ -4,6 +4,7 @@
     "After": "2adc9465c4edfc33834e173fe89436a7cb899a1d",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,

--- a/scm/driver/gitlab/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/tag_create.json.golden
@@ -4,6 +4,7 @@
     "After": "2adc9465c4edfc33834e173fe89436a7cb899a1d",
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,

--- a/scm/driver/gitlab/testdata/webhooks/tag_delete.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/tag_delete.json.golden
@@ -5,6 +5,7 @@
     },
     "Repo": {
         "ID": "4861503",
+        "NodeID": "4861503",
         "Namespace": "gitlab-org",
         "Name": "hello-world",
         "Perm": null,

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -181,6 +181,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 		After:  src.After,
 		Repo: scm.Repository{
 			ID:        strconv.Itoa(src.Project.ID),
+			NodeID:    strconv.Itoa(src.Project.ID),
 			Namespace: namespace,
 			Name:      name,
 			Clone:     src.Project.GitHTTPURL,
@@ -238,6 +239,7 @@ func converBranchHook(src *pushHook) *scm.BranchHook {
 		},
 		Repo: scm.Repository{
 			ID:        strconv.Itoa(src.Project.ID),
+			NodeID:    strconv.Itoa(src.Project.ID),
 			Namespace: namespace,
 			Name:      name,
 			Clone:     src.Project.GitHTTPURL,
@@ -265,6 +267,7 @@ func convertCommentHook(src *commentHook) (*scm.IssueCommentHook, error) {
 	case "MergeRequest":
 		pr := scm.PullRequest{
 			Number:  src.MergeRequest.Iid,
+			NodeID:  strconv.Itoa(src.MergeRequest.ID),
 			Title:   src.MergeRequest.Title,
 			Body:    src.MergeRequest.Description,
 			Sha:     src.MergeRequest.LastCommit.ID,
@@ -312,6 +315,7 @@ func convertCommentHook(src *commentHook) (*scm.IssueCommentHook, error) {
 		Action: scm.ActionCreate,
 		Repo: scm.Repository{
 			ID:        strconv.Itoa(src.Project.ID),
+			NodeID:    strconv.Itoa(src.Project.ID),
 			Namespace: namespace,
 			Name:      src.Repository.Name,
 			Clone:     src.Project.GitHTTPURL,
@@ -343,6 +347,7 @@ func convertTagHook(src *pushHook) *scm.TagHook {
 		},
 		Repo: scm.Repository{
 			ID:        strconv.Itoa(src.Project.ID),
+			NodeID:    strconv.Itoa(src.Project.ID),
 			Namespace: namespace,
 			Name:      name,
 			Clone:     src.Project.GitHTTPURL,
@@ -386,6 +391,7 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 		Action: action,
 		PullRequest: scm.PullRequest{
 			Number: src.ObjectAttributes.Iid,
+			NodeID: strconv.Itoa(src.ObjectAttributes.ID),
 			Title:  src.ObjectAttributes.Title,
 			Body:   src.ObjectAttributes.Description,
 			Sha:    src.ObjectAttributes.LastCommit.ID,
@@ -406,6 +412,7 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 		},
 		Repo: scm.Repository{
 			ID:        strconv.Itoa(src.Project.ID),
+			NodeID:    strconv.Itoa(src.Project.ID),
 			Namespace: namespace,
 			Name:      name,
 			Clone:     src.Project.GitHTTPURL,
@@ -435,6 +442,7 @@ func convertPipelineHook(src *pipelineHook) *scm.PipelineHook {
 	return &scm.PipelineHook{
 		Repo: scm.Repository{
 			ID:        strconv.Itoa(src.Project.ID),
+			NodeID:    strconv.Itoa(src.Project.ID),
 			Namespace: namespace,
 			Name:      name,
 			Clone:     src.Project.GitHTTPURL,
@@ -470,6 +478,7 @@ func convertPipelineHook(src *pipelineHook) *scm.PipelineHook {
 		},
 		PullRequest: scm.PullRequest{
 			Number:  src.MergeRequest.ID,
+			NodeID:  strconv.Itoa(src.MergeRequest.ID),
 			Title:   src.MergeRequest.Title,
 			Sha:     src.ObjectAttributes.SHA,
 			Ref:     src.ObjectAttributes.Ref,

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -13,6 +13,7 @@ type (
 	// PullRequest represents a repository pull request.
 	PullRequest struct {
 		Number  int
+		NodeID  string
 		Title   string
 		Body    string
 		Sha     string

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -13,6 +13,7 @@ type (
 	// Repository represents a git repository.
 	Repository struct {
 		ID         string
+		NodeID     string
 		Namespace  string
 		Name       string
 		Perm       *Perm


### PR DESCRIPTION
## Summary

Adds a `NodeID` field to `scm.Repository` and `scm.PullRequest` and wires it through the GitHub, GitLab, and Bitbucket drivers so consumers receive a provider-stable identifier alongside the existing numeric/UUID `ID`.

- **GitHub**: maps the GraphQL `node_id` from REST payloads via `convertRepository` / `convertPullRequest` and from all inline webhook converters (push, branch, tag, PR, deployment, issue comment, release). The PR review hook already routes through `convertRepository` so it picks the field up automatically.
- **GitLab**: maps the project-scoped numeric `id` for repos, and the global MR `id` (distinct from the project-scoped `iid` surfaced as `Number`) for PRs; applied across all webhook converters, including pipeline hooks where `MergeRequest.ID` is the canonical PR identifier.
- **Bitbucket**: maps the repository `uuid` (already used for `ID`) and the PR numeric `id` (stringified) across REST and webhook flows, including push, branch/tag, PR, PR comment, and pipeline hooks.

The change is purely additive — existing consumers see no behavior change. Downstream callers (e.g. `harness-core`'s SCM proto converters) will be updated in a follow-up to surface `node_id` in `WebhookDTO.parsedResponse`.

## Test plan

- [x] `go test ./...` (all driver suites + integration tests pass)
- [x] `go vet ./scm/...`
- [x] Updated ~60 testdata golden fixtures across three drivers to include the new `NodeID` field
- [ ] Verify downstream `harness-core` build once this is tagged as a pseudo-version

🤖 Generated with [Claude Code](https://claude.com/claude-code)