### PR TITLE
Revert "fix: [PIPE-32312]: add Bitbucket workspace extraction support"

### DIFF
--- a/scm/driver/bitbucket/bitbucket.go
+++ b/scm/driver/bitbucket/bitbucket.go
@@ -27,11 +27,7 @@ func New(uri string) (*scm.Client, error) {
 	if !strings.HasSuffix(base.Path, "/") {
 		base.Path = base.Path + "/"
 	}
-	client := &wrapper{
-		Client:    new(scm.Client),
-		workspace: "",
-		repo:      "",
-	}
+	client := &wrapper{new(scm.Client)}
 	client.BaseURL = base
 	// initialize services
 	client.Driver = scm.DriverBitbucket
@@ -57,22 +53,10 @@ func NewDefault() *scm.Client {
 	return client
 }
 
-// SetWorkspace sets the workspace and repo for the Bitbucket client.
-// This allows the client to use workspace-specific API endpoints without
-// requiring account-level permissions.
-func SetWorkspace(client *scm.Client, workspace, repo string) {
-	if w, ok := client.Repositories.(*repositoryService); ok {
-		w.client.workspace = workspace
-		w.client.repo = repo
-	}
-}
-
 // wraper wraps the Client to provide high level helper functions
 // for making http requests and unmarshaling the response.
 type wrapper struct {
 	*scm.Client
-	workspace string // Bitbucket Cloud workspace extracted from connector URL
-	repo      string // Repository name extracted from connector URL (for repo-level connectors)
 }
 
 // do wraps the Client.Do function by creating the Request and

--- a/scm/driver/bitbucket/util.go
+++ b/scm/driver/bitbucket/util.go
@@ -222,21 +222,10 @@ func (c *wrapper) fetchAllWorkspaces(ctx context.Context) ([]string, error) {
 //	   Fetch 50 repos from ws2 at offset 0. remaining = 0. Done.
 //	hasMore = cumulative(270) > 100+100 → true → Next=3.
 func (c *wrapper) fetchReposWithPagination(ctx context.Context, queryParams string, page, size int) ([]*scm.Repository, *scm.Response, error) {
-	var workspaces []string
-	var err error
-
-	// If workspace is configured in the client, use it directly instead of fetching all workspaces
-	// This allows repo-scoped tokens to work without requiring account scope
-	if c.workspace != "" {
-		workspaces = []string{c.workspace}
-	} else {
-		// Fall back to fetching all workspaces (requires account scope)
-		workspaces, err = c.fetchAllWorkspaces(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
+	workspaces, err := c.fetchAllWorkspaces(ctx)
+	if err != nil {
+		return nil, nil, err
 	}
-
 	if len(workspaces) == 0 {
 		return []*scm.Repository{}, &scm.Response{}, nil
 	}

--- a/scm/driver/bitbucket/util_helpers_test.go
+++ b/scm/driver/bitbucket/util_helpers_test.go
@@ -44,7 +44,7 @@ func TestCalculateLocalOffset(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
+	w := &wrapper{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := w.calculateLocalOffset(tt.globalOffset, tt.wsStart)
@@ -101,7 +101,7 @@ func TestCalculateReposNeeded(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
+	w := &wrapper{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := w.calculateReposNeeded(tt.wsCount, tt.localOffset, tt.remaining)
@@ -171,7 +171,7 @@ func TestDetermineHasMoreAndContinue(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
+	w := &wrapper{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			state := &paginationState{remaining: tt.remaining}
@@ -289,7 +289,7 @@ func TestGetSliceStartAndCheck(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
+	w := &wrapper{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create dummy repos slice of appropriate length
@@ -360,7 +360,7 @@ func TestGetSliceEnd(t *testing.T) {
 		},
 	}
 
-	w := &wrapper{Client: new(scm.Client), workspace: "", repo: ""}
+	w := &wrapper{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := w.getSliceEndIdx(tt.reposLen, tt.start, tt.limit, tt.collected)

--- a/scm/driver/bitbucket/util_test.go
+++ b/scm/driver/bitbucket/util_test.go
@@ -239,11 +239,7 @@ func Test_extractWorkspaceFromURL(t *testing.T) {
 			if !strings.HasSuffix(u.Path, "/") {
 				u.Path = u.Path + "/"
 			}
-			w := &wrapper{
-				Client:    &scm.Client{BaseURL: u},
-				workspace: "",
-				repo:      "",
-			}
+			w := &wrapper{&scm.Client{BaseURL: u}}
 			got := w.extractWorkspaceFromURL()
 			if got != tt.want {
 				t.Errorf("extractWorkspaceFromURL() = %q, want %q", got, tt.want)


### PR DESCRIPTION
## Summary

Reverts commit `66cedce` which was only on Harness Code master and was never merged into GitHub. This restores both remotes to the same state.

- Reverts workspace/SetWorkspace() changes to `scm/driver/bitbucket/bitbucket.go`
- Reverts utility changes to `scm/driver/bitbucket/util.go`
- Reverts test updates to `util_helpers_test.go` and `util_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)